### PR TITLE
Fixes build_url replacing 'https://' for 'https:/'

### DIFF
--- a/lib/utils/build_url.js
+++ b/lib/utils/build_url.js
@@ -2,9 +2,11 @@ const isBrowser = typeof location !== 'undefined' && typeof document !== 'undefi
 const qs = isBrowser ? require('./querystring_lite') : require('querystring')
 
 module.exports = instance => {
-  const instanceApiEndpoint = (
-    `${instance}/`.replace(/\/\/$/, '/') + 'w/api.php'
-  ).replace('/w/api.php/w/api.php', '/w/api.php')
+  const instanceApiEndpoint = instance.endsWith('/w/api.php')
+    ? instance
+    : instance.endsWith('/')
+    ? instance + 'w/api.php'
+    : instance + '/w/api.php'
 
   return queryObj => {
     // Request CORS headers if the request is made from a browser

--- a/lib/utils/build_url.js
+++ b/lib/utils/build_url.js
@@ -3,7 +3,7 @@ const qs = isBrowser ? require('./querystring_lite') : require('querystring')
 
 module.exports = instance => {
   const instanceApiEndpoint = `${instance}/w/api.php`
-    .replace('//', '/')
+    .replace(/\/\/$/, '/')
     .replace('/w/api.php/w/api.php', '/w/api.php')
 
   return queryObj => {

--- a/lib/utils/build_url.js
+++ b/lib/utils/build_url.js
@@ -2,9 +2,9 @@ const isBrowser = typeof location !== 'undefined' && typeof document !== 'undefi
 const qs = isBrowser ? require('./querystring_lite') : require('querystring')
 
 module.exports = instance => {
-  const instanceApiEndpoint = `${instance}/w/api.php`
-    .replace(/\/\/$/, '/')
-    .replace('/w/api.php/w/api.php', '/w/api.php')
+  const instanceApiEndpoint = (
+    `${instance}/`.replace(/\/\/$/, '/') + 'w/api.php'
+  ).replace('/w/api.php/w/api.php', '/w/api.php')
 
   return queryObj => {
     // Request CORS headers if the request is made from a browser


### PR DESCRIPTION
Title says it all, in current version I'm getting:

```js
> require('wikidata-sdk').searchEntities('ingmar Bergman')

'https:/www.wikidata.org/w/api.php?action=wbsearchentities&search=ingmar%20Bergman&language=en&limit=20&continue=&format=json&uselang=en&type=item'
```

Note the 'https:/www...'.
Thanks for the awesome lib btw