### PR TITLE
types: add basic v7 types

### DIFF
--- a/lib/wikibase-sdk.js
+++ b/lib/wikibase-sdk.js
@@ -92,3 +92,4 @@ const missingSparqlEndpoint = missingConfig('a sparqlEndpoint')
 const missingInstance = missingConfig('an instance')
 
 module.exports = WBK
+module.exports.default = WBK

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "7.4.1",
   "description": "utils functions to query a Wikibase instance and simplify its results",
   "main": "lib/wikibase-sdk.js",
+  "types": "types",
   "files": [
     "lib",
-    "types/**/*.d.ts"
+    "types/**/*.d.ts",
+    "!types/test"
   ],
   "directories": {
     "lib": "lib",
@@ -20,6 +22,7 @@
     "lint-fix": "standardx --verbose --fix",
     "minify": "./scripts/minify",
     "test": "mocha",
+    "test-types": "tsc",
     "prepublishOnly": "npm run lint && npm test",
     "postpublish": "./scripts/postpublish",
     "update-dist": "./scripts/update_dist",
@@ -57,6 +60,7 @@
     "should": "^13.2.1",
     "standardx": "^5.0.0",
     "tiny-chalk": "^2.0.0",
+    "typescript": "^3.8.3",
     "uglify-js": "^3.3.25"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true
+    },
+    "include": [
+      "types"
+    ]
+}

--- a/types/claim.d.ts
+++ b/types/claim.d.ts
@@ -1,0 +1,54 @@
+export type ClaimRank = 'normal' | 'preferred' | 'deprecated'
+
+export type ClaimSimplified = unknown;
+export type ClaimSnakSimplified = unknown;
+
+export interface Claim {
+	id: string;
+	mainsnak: ClaimSnak;
+	rank: ClaimRank;
+	type: string;
+	qualifiers?: Record<string, ClaimSnak[]>;
+	'qualifiers-order'?: string[];
+	references?: ClaimReference[];
+}
+
+export interface ClaimSnak {
+	datatype: string;
+	datavalue?: ClaimSnakValue;
+	hash: string;
+	property: string;
+	snaktype: string;
+}
+
+export interface ClaimSnakValue {
+	type: string;
+	value: unknown;
+}
+
+export interface ClaimSnakTimeValue extends ClaimSnakValue {
+	type: 'time';
+	value: {
+		after: number;
+		before: number;
+		calendermodel: string;
+		precision: number;
+		time: string;
+		timezone: number;
+	};
+}
+
+export interface ClaimSnakEntityValue extends ClaimSnakValue {
+	type: 'wikibase-entityid';
+	value: {
+		id: string;
+		'numeric-id': number;
+		'entity-type': string;
+	};
+}
+
+export interface ClaimReference {
+	hash: string;
+	snaks: Record<string, ClaimSnak[]>;
+	'snaks-order': string[];
+}

--- a/types/entity.d.ts
+++ b/types/entity.d.ts
@@ -1,0 +1,48 @@
+import {Claim, ClaimSimplified} from './claim.d'
+
+export interface LanguageEntry {
+	language: string;
+	value: string;
+}
+
+export interface Entity {
+	type: string;
+	datatype?: string;
+	id: string;
+
+	// Info
+	pageid?: number;
+	ns?: number;
+	title?: string;
+	lastrevid?: number;
+	modified?: string;
+	redirects?: {from: string, to: string};
+
+	// Available when asked for in GetEntitiesOptions
+	aliases?: Record<string, LanguageEntry[]>;
+	claims?: Record<string, Claim[]>;
+	descriptions?: Record<string, LanguageEntry>;
+	labels?: Record<string, LanguageEntry>;
+	sitelinks?: Record<string, Sitelink>;
+}
+
+export interface EntitySimplified {
+	type: string;
+	id: string;
+
+	// Info
+	modified?: string;
+
+	aliases?: Record<string, string[]>;
+	claims?: Record<string, ClaimSimplified[]>;
+	descriptions?: Record<string, string>;
+	labels?: Record<string, string>;
+	sitelinks?: {[site: string]: string};
+}
+
+export interface Sitelink {
+	site: string;
+	title: string;
+	badges: string[];
+	url?: string;
+}

--- a/types/helpers.d.ts
+++ b/types/helpers.d.ts
@@ -1,0 +1,18 @@
+export function isNumericId(id: string): boolean;
+export function isEntityId(id: string): boolean;
+export function isItemId(id: string): boolean;
+export function isPropertyId(id: string): boolean;
+export function isFormId(id: string): boolean;
+export function isSenseId(id: string): boolean;
+export function isGuid(guid: string): boolean;
+
+export function isEntityPageTitle(title: string): boolean;
+
+export function getNumericId(id: string): number;
+
+export function wikibaseTimeToDateObject(wikidataTime: string): Date;
+export function wikibaseTimeToEpochTime(wikidataTime: string): number;
+export function wikibaseTimeToISOString(wikidataTime: string): string;
+export function wikibaseTimeToSimpleDay(wikidataTime: string): string;
+
+export function getImageUrl(filename: string, width?: number): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,29 @@
+import {WikibaseApiFunctions} from './wikibase-api-functions.d'
+import {WikibaseQueryServiceFunctions} from './wikibase-query-service-functions'
+
+export * from './claim.d'
+export * from './entity.d'
+export * from './options.d'
+export * from './sparql.d'
+export * from './search.d'
+
+export * as simplify from './simplify.d'
+export * from './rank.d'
+export * from './sitelinks.d'
+export * from './helpers.d'
+
+export interface Instance {
+	root: string;
+	apiEndpoint: string;
+}
+
+export interface WikibaseInstanceSDK extends WikibaseApiFunctions, WikibaseQueryServiceFunctions {
+	instance: Instance;
+}
+
+export interface Config {
+	instance: string,
+	sparqlEndpoint: string;
+}
+
+export default function WBK(config: Config): WikibaseInstanceSDK;

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,0 +1,60 @@
+export type Property = 'info' | 'sitelinks' | 'sitelinks/urls' | 'aliases' | 'labels' | 'descriptions' | 'claims' | 'datatype';
+export type SearchType = 'item' | 'property' | 'lexeme' | 'form' | 'sense'
+export type UrlResultFormat = 'xml' | 'json';
+
+export interface GetEntitiesFromSitelinksOptions {
+	titles: string | string[];
+	sites: string | string[];
+	languages?: string | string[];
+	props?: string | string[];
+	format?: UrlResultFormat;
+}
+
+export interface GetEntitiesOptions {
+	ids: string | string[];
+	languages?: string | string[];
+	props?: Property | Property[];
+	format?: UrlResultFormat;
+}
+
+export interface GetReverseClaimOptions {
+	limit?: number;
+	keepProperties?: boolean;
+	caseInsensitive?: boolean;
+}
+
+export interface GetRevisionsOptions {
+	limit?: number;
+	start?: string | number;
+	end?: string | number;
+}
+
+export interface SearchEntitiesOptions {
+	search: string;
+	language?: string;
+	limit?: number;
+	format?: UrlResultFormat;
+	uselang?: string;
+	type?: SearchType;
+}
+
+export interface SimplifyClaimsOptions {
+	entityPrefix?: string;
+	propertyPrefix?: string;
+	keepRichValues?: boolean;
+	keepTypes?: boolean;
+	keepQualifiers?: boolean;
+	keepReferences?: boolean;
+	keepIds?: boolean;
+	keepHashes?: boolean;
+	keepNonTruthy?: boolean;
+	timeConverter?: 'iso' | 'epoch' | 'simple-day' | 'none';
+	novalueValue: any;
+	somevalueValue: any;
+}
+
+export interface SimplifyEntitiesOptions extends SimplifyClaimsOptions, SimplifySitelinkOptions {}
+
+export interface SimplifySitelinkOptions {
+	addUrl?: boolean;
+}

--- a/types/rank.d.ts
+++ b/types/rank.d.ts
@@ -1,0 +1,4 @@
+import {Claim} from './claim.d'
+
+export function truthyClaims(claims: Record<string, Claim[]>): Record<string, Claim[]>;
+export function truthyPropertyClaims(claims: Claim[]): Claim[];

--- a/types/search.d.ts
+++ b/types/search.d.ts
@@ -1,0 +1,16 @@
+export interface SearchResult {
+	aliases?: string[]
+	concepturi: string;
+	description?: string;
+	id: string;
+	label: string;
+	match: {
+		language: string;
+		text: string;
+		type: string;
+	};
+	pageid: number;
+	repository: string;
+	title: string;
+	url: string;
+}

--- a/types/simplify.d.ts
+++ b/types/simplify.d.ts
@@ -1,0 +1,45 @@
+import {
+	SimplifyClaimsOptions,
+	SimplifyEntitiesOptions,
+	SimplifySitelinkOptions
+} from './options.d'
+
+import {
+	Claim,
+	ClaimSimplified,
+	ClaimSnak,
+	ClaimSnakSimplified
+} from './claim.d'
+
+import {
+	Entity,
+	EntitySimplified,
+	LanguageEntry,
+	Sitelink
+} from './entity.d'
+
+import {
+	SparqlValueRaw,
+	SparqlValueType,
+	SparqlResults
+} from './sparql.d'
+
+export function labels(data: Record<string, LanguageEntry>): Record<string, string>;
+export function descriptions(data: Record<string, LanguageEntry>): Record<string, string>;
+export function aliases(data: Record<string, LanguageEntry[]>): Record<string, string[]>;
+
+export function entity(entity: Entity, options?: SimplifyEntitiesOptions): EntitySimplified;
+export function entities(entities: Record<string, Entity>, options?: SimplifyEntitiesOptions): Record<string, EntitySimplified>;
+export function sparqlResults(results: SparqlResults, options?: {minimize?: false}): Record<string, SparqlValueType>[];
+export function sparqlResults(results: SparqlResults, options: {minimize: true}): SparqlValueRaw[];
+
+export function claims(claims: Record<string, Claim[]>, options?: SimplifyClaimsOptions): Record<string, ClaimSimplified[]>;
+export function propertyClaims(propClaims: Claim[], options?: SimplifyClaimsOptions): ClaimSimplified[];
+export function claim(claim: Claim, options?: SimplifyClaimsOptions): ClaimSimplified;
+
+export function qualifiers(qualifiers: Record<string, ClaimSnak[]>, options?: SimplifyClaimsOptions): Record<string, ClaimSnakSimplified[]>;
+export function propertyQualifiers(propQualifiers: ClaimSnak[], options?: SimplifyClaimsOptions): ClaimSnakSimplified[];
+export function qualifier(qualifier: ClaimSnak, options?: SimplifyClaimsOptions): ClaimSnakSimplified;
+
+export function sitelinks(sitelinks: Record<string, Sitelink>, options?: {addUrl?: false} & SimplifySitelinkOptions): Record<string, string>;
+export function sitelinks(sitelinks: Record<string, Sitelink>, options?: {addUrl: true} & SimplifySitelinkOptions): Record<string, {title: string, url: string}>;

--- a/types/sitelinks.d.ts
+++ b/types/sitelinks.d.ts
@@ -1,0 +1,3 @@
+export function getSitelinkUrl(site: string, title: string): string;
+export function getSitelinkData(site: string): {lang: string; project: string};
+export function isSitelinkKey(site: string): boolean;

--- a/types/sparql.d.ts
+++ b/types/sparql.d.ts
@@ -1,0 +1,11 @@
+export type SparqlValueRaw = string | number
+export type SparqlValueType = SparqlValueRaw | Record<string, SparqlValueRaw>
+
+export interface SparqlResults {
+	head: {
+		vars: string[];
+	};
+	results: {
+		bindings: any[];
+	};
+}

--- a/types/test/README.md
+++ b/types/test/README.md
@@ -1,0 +1,5 @@
+# Check Typescript Types
+
+These files do not have to "work". They have to compile with typescript typing.
+
+Use: `npm run test-types`

--- a/types/test/independent.ts
+++ b/types/test/independent.ts
@@ -1,0 +1,44 @@
+import {Entity, EntitySimplified, Claim, ClaimSimplified, simplify, isEntityId} from '..';
+
+isEntityId('Q1337');
+
+const entity: Entity = {
+	datatype: 'wikibase-item',
+	id: 'P31',
+	labels: {
+		en: {
+			language: 'en',
+			value: 'instance of',
+		},
+	},
+	type: 'property',
+};
+
+const simplifiedEntitiy: EntitySimplified = simplify.entity(entity);
+
+const simplifiedEntities = simplify.entities({P31: entity});
+
+const claim: Claim = {
+	id: 'Q42$88CB3380-ADFB-427B-87E5-C8D537545FE8',
+	mainsnak: {
+		datatype: 'monolingualtext',
+		datavalue: {
+			type: 'monolingualtext',
+			value: {
+				language: 'en',
+				text: 'Douglas Adams',
+			},
+		},
+		hash: '95644e72f595a3bc535e0eb316325ee88d9466f8',
+		property: 'P1559',
+		snaktype: 'value',
+	},
+	rank: 'normal',
+	type: 'statement',
+}
+
+const simplifiedClaim: ClaimSimplified = simplify.claim(claim)
+
+const simplifiedPropClaims: ClaimSimplified[] = simplify.propertyClaims([claim])
+
+const simplifiedClaims: Record<string, ClaimSimplified[]> = simplify.claims({P1559: [claim]})

--- a/types/test/instance-specific.ts
+++ b/types/test/instance-specific.ts
@@ -1,0 +1,13 @@
+import WBK from '..';
+
+const wbk = WBK({
+	instance: '',
+	sparqlEndpoint: ''
+})
+
+
+const searchUrl: string = wbk.searchEntities('erde', 'de', 42, 'xml', 'de');
+
+const entityUrl: string = wbk.getEntities('Q5', 'de', ['labels', 'claims']);
+
+const queryUrl: string = wbk.sparqlQuery('SELECT * FROM {}');

--- a/types/test/simplify-qualifier.ts
+++ b/types/test/simplify-qualifier.ts
@@ -1,0 +1,51 @@
+import {Claim, ClaimSnakSimplified, simplify} from '..';
+
+const claimWithQualifier: Claim = {
+	id: 'q42$881F40DC-0AFE-4FEB-B882-79600D234273',
+	mainsnak: {
+		datatype: 'wikibase-item',
+		datavalue: {
+			type: 'wikibase-entityid',
+			value: {
+				'entity-type': 'item',
+				id: 'Q533697',
+				'numeric-id': 533697,
+			},
+		},
+		hash: 'f22d367759fe126d0723a18e59399e4206b8f37d',
+		property: 'P119',
+		snaktype: 'value',
+	},
+	qualifiers: {
+		P625: [
+			{
+				datatype: 'globe-coordinate',
+				datavalue: {
+					type: 'globecoordinate',
+					value: {
+						altitude: null,
+						globe: 'http://www.wikidata.org/entity/Q2',
+						latitude: 51.566516666667,
+						longitude: -0.14549722222222,
+						precision: 0.0000027777777777778,
+					},
+				},
+				hash: '115724b2b32baa9a00e3c161c1282252ae955964',
+				property: 'P625',
+				snaktype: 'value',
+			},
+		],
+	},
+	'qualifiers-order': [
+		'P625',
+	],
+	rank: 'normal',
+	type: 'statement',
+}
+
+function simplifyQualifier(): void {
+	const qualifiers = claimWithQualifier.qualifiers!
+	const simplifiedQualifier: ClaimSnakSimplified = simplify.qualifier(qualifiers.P625[0])
+	const simplifiedPropQualifiers: ClaimSnakSimplified[] = simplify.propertyQualifiers(qualifiers.P625)
+	const simplifiedQualifiers: Record<string, ClaimSnakSimplified[]> = simplify.qualifiers(qualifiers)
+}

--- a/types/wikibase-api-functions.d.ts
+++ b/types/wikibase-api-functions.d.ts
@@ -1,0 +1,32 @@
+import {
+	GetEntitiesFromSitelinksOptions,
+	GetEntitiesOptions,
+	Property,
+	UrlResultFormat,
+    GetRevisionsOptions,
+    SearchEntitiesOptions
+} from './options.d'
+
+export function searchEntities(search: string, language?: string, limit?: number, format?: UrlResultFormat, uselang?: string): string;
+export function searchEntities(options: SearchEntitiesOptions): string;
+
+export function getEntities(ids: string | string[], languages?: string | string[], props?: Property | Property[], format?: UrlResultFormat): string;
+export function getEntities(options: GetEntitiesOptions): string;
+
+export function getManyEntities(ids: string | string[], languages?: string | string[], props?: Property | Property[], format?: UrlResultFormat): string[];
+export function getManyEntities(options: GetEntitiesOptions): string[];
+
+export function getRevisions(ids: string | string[], options?: GetRevisionsOptions): string;
+
+// TODO: getEntityRevision
+
+export function getEntitiesFromSitelinks(titles: string | string[], sites: string | string[], languages?: string | string[], props?: string | string[], format?: UrlResultFormat): string;
+export function getEntitiesFromSitelinks(options: GetEntitiesFromSitelinksOptions): string;
+
+declare interface WikibaseApiFunctions {
+    readonly searchEntities: typeof searchEntities;
+    readonly getEntities: typeof getEntities;
+    readonly getManyEntities: typeof getManyEntities;
+    readonly getRevisions: typeof getRevisions;
+    readonly getEntitiesFromSitelinks: typeof getEntitiesFromSitelinks;
+}

--- a/types/wikibase-query-service-functions.d.ts
+++ b/types/wikibase-query-service-functions.d.ts
@@ -1,0 +1,10 @@
+import {GetReverseClaimOptions} from './options'
+
+export function sparqlQuery(query: string): string;
+
+export function getReverseClaims(property: string | string[], value: string | string[], options?: GetReverseClaimOptions): string;
+
+declare interface WikibaseQueryServiceFunctions {
+    readonly sparqlQuery: typeof sparqlQuery;
+    readonly getReverseClaims: typeof getReverseClaims;
+}

--- a/wikidata-sdk/package.json
+++ b/wikidata-sdk/package.json
@@ -3,10 +3,8 @@
   "version": "*",
   "description": "A convenience package bundling wikibase-sdk initialized with wikidata.org config",
   "main": "./wikidata-sdk.js",
-  "types": "types/index.d.ts",
-  "scripts": {
-    "test-types": "tsc"
-  },
+  "types": "./wikidata-sdk.d.ts",
+  "scripts": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/maxlath/wikidata-sdk"
@@ -28,9 +26,7 @@
   "dependencies": {
     "wikibase-sdk": "*"
   },
-  "devDependencies": {
-    "typescript": "^3.5.1"
-  },
+  "devDependencies": {},
   "engines": {
     "node": ">= 6.4"
   }

--- a/wikidata-sdk/wikidata-sdk.d.ts
+++ b/wikidata-sdk/wikidata-sdk.d.ts
@@ -1,0 +1,3 @@
+import {WikibaseInstanceSDK} from 'wikibase-sdk'
+declare const wdk: WikibaseInstanceSDK
+export default wdk


### PR DESCRIPTION
The function returning the library results in a hard to type library... I simplified a bunch of things so some things are only typed one way and not the other.

closes #61 

commons are not accessible via `WBK({…}).isEntityId`.
They can only be used as direct `import (import {isEntityId} from …)`.

Typing both creates a lot of ugly code that did not seem as necessary

`wikidata-sdk` has to be used with `wikibase-sdk` typings because of these common imports:
```ts
import wdk from 'wikidata-sdk'
import {isEntityId} from 'wikibase-sdk'
```

I tested the typings with existing code of mine I updated to v7.

Personally I would like to separate this library into two separate things/repos: methods independent from the Wikibase instance and methods using a specific instance. These should only have one way to include. The 'commons' can currently be either imported directly or used from the instance specific object which makes them way more complicated than I expected before.