### PR TITLE
added information on the required user agent

### DIFF
--- a/docs/sparql_query.md
+++ b/docs/sparql_query.md
@@ -9,9 +9,11 @@ const wbk = require('wikibase-sdk')({
 })
 const sparql = 'SELECT * WHERE { ?s ?p ? o } LIMIT 10'
 const url = wbk.sparqlQuery(sparql)
+const headers = { 'User-Agent': '<FILL IN YOUR USER-AGENT INFORMATION>' }; // see https://meta.wikimedia.org/wiki/User-Agent_policy
 // request the generated URL with your favorite HTTP request library
-request({ method: 'GET', url })
+request({ method: 'GET', url, headers})
 ```
+For more information on including the correct [User-Agent](https://meta.wikimedia.org/wiki/User-Agent_policy)
 You can then simplify the response using [`wbk.simplify.sparqlResults`](simplify_sparql_results.md).
 
 ### Example


### PR DESCRIPTION
The example code does not wrok without adding a user agent in the header of the request.