### PR TITLE
refactor: improve typings of helpers and utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "9.0.3",
       "license": "MIT",
       "devDependencies": {
+        "@types/lodash-es": "^4.17.6",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.11.18",
         "@types/should": "^13.0.0",
@@ -280,6 +281,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.6.tgz",
+      "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mocha": {
       "version": "10.0.1",
@@ -4042,6 +4058,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
+    },
+    "@types/lodash-es": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.6.tgz",
+      "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/mocha": {
       "version": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "homepage": "https://github.com/maxlath/wikibase-sdk",
   "devDependencies": {
+    "@types/lodash-es": "^4.17.6",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.18",
     "@types/should": "^13.0.0",

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,59 +1,100 @@
 import { wikibaseTimeToDateObject as toDateObject } from './wikibase_time_to_date_object.js'
+import type {
+  EntityId,
+  EntityPageTitle,
+  EntitySchemaId,
+  FormId,
+  Guid,
+  Hash,
+  ItemId,
+  LexemeId,
+  NonNestedEntityId,
+  NumericId,
+  PropertyClaimsId,
+  PropertyId,
+  RevisionId,
+  SenseId,
+} from '../types/entity.js'
 import type { Url } from '../types/options.js'
 
-export const isNumericId = (id: string): boolean => /^[1-9][0-9]*$/.test(id)
+export function isNumericId (id: unknown): id is NumericId {
+  return typeof id === 'string' && /^[1-9][0-9]*$/.test(id)
+}
 
-export const isEntityId = (id: string): boolean => /^((Q|P|L|M)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)$/.test(id)
+export function isEntityId (id: unknown): id is EntityId {
+  return typeof id === 'string' &&
+    /^((Q|P|L|M)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)$/.test(id)
+}
 
-export const isEntitySchemaId = (id: string): boolean => /^E[1-9][0-9]*$/.test(id)
+export function isEntitySchemaId (id: unknown): id is EntitySchemaId {
+  return typeof id === 'string' && /^E[1-9][0-9]*$/.test(id)
+}
 
-export const isItemId = (id: string): boolean => /^Q[1-9][0-9]*$/.test(id)
+export function isItemId (id: unknown): id is ItemId {
+  return typeof id === 'string' && /^Q[1-9][0-9]*$/.test(id)
+}
 
-export const isPropertyId = (id: string): boolean => /^P[1-9][0-9]*$/.test(id)
+export function isPropertyId (id: unknown): id is PropertyId {
+  return typeof id === 'string' && /^P[1-9][0-9]*$/.test(id)
+}
 
-export const isLexemeId = (id: string): boolean => /^L[1-9][0-9]*$/.test(id)
+export function isLexemeId (id: unknown): id is LexemeId {
+  return typeof id === 'string' && /^L[1-9][0-9]*$/.test(id)
+}
 
-export const isFormId = (id: string): boolean => /^L[1-9][0-9]*-F[1-9][0-9]*$/.test(id)
+export function isFormId (id: unknown): id is FormId {
+  return typeof id === 'string' && /^L[1-9][0-9]*-F[1-9][0-9]*$/.test(id)
+}
 
-export const isSenseId = (id: string): boolean => /^L[1-9][0-9]*-S[1-9][0-9]*$/.test(id)
+export function isSenseId (id: unknown): id is SenseId {
+  return typeof id === 'string' && /^L[1-9][0-9]*-S[1-9][0-9]*$/.test(id)
+}
 
-export const isGuid = (guid: string): boolean => /^((Q|P|L)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)\$[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(guid)
+export function isGuid (guid: unknown): guid is Guid {
+  return typeof guid === 'string' &&
+    /^((Q|P|L)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)\$[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      .test(guid)
+}
 
-export const isHash = (hash: string): boolean => /^[0-9a-f]{40}$/.test(hash)
+export function isHash (hash: unknown): hash is Hash {
+  return typeof hash === 'string' && /^[0-9a-f]{40}$/.test(hash)
+}
 
-export function isPropertyClaimsId (id: string): boolean {
+export function isPropertyClaimsId (id: unknown): id is PropertyClaimsId {
+  if (typeof id !== 'string') return false
   const [ entityId, propertyId ] = id.split('#')
   return isEntityId(entityId) && isPropertyId(propertyId)
 }
 
-export const isRevisionId = (id: string): boolean => /^\d+$/.test(id)
+export function isRevisionId (id: unknown): id is RevisionId {
+  return typeof id === 'string' && /^\d+$/.test(id)
+}
 
-export function isEntityPageTitle (title: string): boolean {
+export function isEntityPageTitle (title: unknown): title is EntityPageTitle {
   if (typeof title !== 'string') return false
-  let [ namespace, id ] = title.split(':')
-  if (namespace && id) {
-    return isEntityNamespace(namespace) && idTestByNamespace[namespace](id)
-  } else {
-    id = namespace
-    return isItemId(id)
+
+  if (title.startsWith('Item:')) {
+    return isItemId(title.substring(5))
   }
+
+  if (title.startsWith('Lexeme:')) {
+    return isLexemeId(title.substring(7))
+  }
+
+  if (title.startsWith('Property:')) {
+    return isPropertyId(title.substring(9))
+  }
+
+  return isItemId(title)
 }
 
-const entityNamespaces = [ 'Item', 'Property', 'Lexeme' ]
-
-const isEntityNamespace = str => entityNamespaces.includes(str)
-
-const idTestByNamespace = {
-  Item: isItemId,
-  Lexeme: isLexemeId,
-  Property: isPropertyId,
+function isNonNestedEntityId (id: unknown): id is NonNestedEntityId {
+  return typeof id === 'string' && /^(Q|P|L)[1-9][0-9]*$/.test(id)
 }
 
-const isNonNestedEntityId = (id: string): boolean => /^(Q|P|L)[1-9][0-9]*$/.test(id)
-
-export function getNumericId (id: string): string {
+export function getNumericId (id: unknown): NumericId {
   if (!isNonNestedEntityId(id)) throw new Error(`invalid entity id: ${id}`)
-  return id.replace(/^(Q|P|L)/, '')
+  return id.replace(/^(Q|P|L)/, '') as NumericId
 }
 
 export interface WikibaseTimeObject {
@@ -63,27 +104,31 @@ export interface WikibaseTimeObject {
 
 export type TimeInputValue = string | WikibaseTimeObject
 
-export type TimeFunction = (wikibaseTime: TimeInputValue) => any
+type TimeFunction<T> = (wikibaseTime: TimeInputValue) => T
 
 // Try to parse the date or return the input
-const bestEffort = (fn: TimeFunction) => (value: TimeInputValue) => {
-  try {
-    return fn(value)
-  } catch (err) {
-    // @ts-ignore
-    value = value.time || value
+function bestEffort<T> (fn: TimeFunction<T>) {
+  return (value: TimeInputValue) => {
+    try {
+      return fn(value)
+    } catch (err) {
+      value = typeof value === 'string' ? value : value.time
 
-    const sign = value[0]
-    // @ts-ignore
-    let [ yearMonthDay, withinDay ] = value.slice(1).split('T')
-    yearMonthDay = yearMonthDay.replace(/-00/g, '-01')
+      const sign = value[0]
+      let [ yearMonthDay, withinDay ] = value.slice(1).split('T')
+      if (!sign || !yearMonthDay || !withinDay) {
+        throw new Error('TimeInput is invalid: ' + JSON.stringify(value))
+      }
 
-    return `${sign}${yearMonthDay}T${withinDay}`
+      yearMonthDay = yearMonthDay.replace(/-00/g, '-01')
+
+      return `${sign}${yearMonthDay}T${withinDay}`
+    }
   }
 }
 
-const toEpochTime = (wikibaseTime: TimeInputValue): number => toDateObject(wikibaseTime).getTime()
-const toISOString = (wikibaseTime: TimeInputValue): string => toDateObject(wikibaseTime).toISOString()
+const toEpochTime = (wikibaseTime: TimeInputValue) => toDateObject(wikibaseTime).getTime()
+const toISOString = (wikibaseTime: TimeInputValue) => toDateObject(wikibaseTime).toISOString()
 
 // A date format that knows just three precisions:
 // 'yyyy', 'yyyy-mm', and 'yyyy-mm-dd' (including negative and non-4 digit years)
@@ -96,8 +141,7 @@ const toSimpleDay = (wikibaseTime: TimeInputValue): string => {
   // Also accept claim datavalue.value objects, and actually prefer those,
   // as we can check the precision
   if (typeof wikibaseTime === 'object') {
-    const wikibaseTimeObject = wikibaseTime as WikibaseTimeObject
-    const { time, precision } = wikibaseTimeObject
+    const { time, precision } = wikibaseTime
     // Year precision
     if (precision === 9) wikibaseTime = time.replace('-01-01T', '-00-00T')
     // Month precision
@@ -106,14 +150,14 @@ const toSimpleDay = (wikibaseTime: TimeInputValue): string => {
   }
 
   return wikibaseTime.split('T')[0]
-  // Remove positive years sign
-  .replace(/^\+/, '')
-  // Remove years padding zeros
-  .replace(/^(-?)0+/, '$1')
-  // Remove days if not included in the Wikidata date precision
-  .replace(/-00$/, '')
-  // Remove months if not included in the Wikidata date precision
-  .replace(/-00$/, '')
+    // Remove positive years sign
+    .replace(/^\+/, '')
+    // Remove years padding zeros
+    .replace(/^(-?)0+/, '$1')
+    // Remove days if not included in the Wikidata date precision
+    .replace(/-00$/, '')
+    // Remove months if not included in the Wikidata date precision
+    .replace(/-00$/, '')
 }
 
 export const wikibaseTimeToEpochTime = bestEffort(toEpochTime)
@@ -130,18 +174,18 @@ export function getImageUrl (filename: string, width?: number): Url {
   return url
 }
 
-export function getEntityIdFromGuid (guid: string): string {
+export function getEntityIdFromGuid (guid: Guid): EntityId {
   const parts = guid.split(/[$-]/)
   if (parts.length === 6) {
     // Examples:
     // - q520$BCA8D9DE-B467-473B-943C-6FD0C5B3D02C
     // - P6216-a7fd6230-496e-6b47-ca4a-dcec5dbd7f95
-    return parts[0].toUpperCase()
+    return parts[0].toUpperCase() as EntityId
   } else if (parts.length === 7) {
     // Examples:
     // - L525-S1$66D20252-8CEC-4DB1-8B00-D713CFF42E48
     // - L525-F2-52c9b382-02f5-4413-9923-26ade74f5a0d
-    return parts.slice(0, 2).join('-').toUpperCase()
+    return parts.slice(0, 2).join('-').toUpperCase() as EntityId
   } else {
     throw new Error(`invalid guid: ${guid}`)
   }

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -17,60 +17,30 @@ import type {
 } from '../types/entity.js'
 import type { Url } from '../types/options.js'
 
-export function isNumericId (id: unknown): id is NumericId {
-  return typeof id === 'string' && /^[1-9][0-9]*$/.test(id)
+function isIdBuilder<T extends string> (regex: {readonly source: string, readonly flags: string}) {
+  return (id: string): id is T => typeof id === 'string' && new RegExp(regex.source, regex.flags).test(id)
 }
 
-export function isEntityId (id: unknown): id is EntityId {
-  return typeof id === 'string' &&
-    /^((Q|P|L|M)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)$/.test(id)
-}
+export const isNumericId = isIdBuilder<NumericId>(/^[1-9][0-9]*$/)
+export const isEntityId = isIdBuilder<EntityId>(/^((Q|P|L|M)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)$/)
+export const isEntitySchemaId = isIdBuilder<EntitySchemaId>(/^E[1-9][0-9]*$/)
+export const isItemId = isIdBuilder<ItemId>(/^Q[1-9][0-9]*$/)
+export const isPropertyId = isIdBuilder<PropertyId>(/^P[1-9][0-9]*$/)
+export const isLexemeId = isIdBuilder<LexemeId>(/^L[1-9][0-9]*$/)
+export const isFormId = isIdBuilder<FormId>(/^L[1-9][0-9]*-F[1-9][0-9]*$/)
+export const isSenseId = isIdBuilder<SenseId>(/^L[1-9][0-9]*-S[1-9][0-9]*$/)
+export const isGuid = isIdBuilder<Guid>(/^((Q|P|L)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)\$[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+export const isHash = isIdBuilder<Hash>(/^[0-9a-f]{40}$/)
+export const isRevisionId = isIdBuilder<RevisionId>(/^\d+$/)
+export const isNonNestedEntityId = isIdBuilder<NonNestedEntityId>(/^(Q|P|L)[1-9][0-9]*$/)
 
-export function isEntitySchemaId (id: unknown): id is EntitySchemaId {
-  return typeof id === 'string' && /^E[1-9][0-9]*$/.test(id)
-}
-
-export function isItemId (id: unknown): id is ItemId {
-  return typeof id === 'string' && /^Q[1-9][0-9]*$/.test(id)
-}
-
-export function isPropertyId (id: unknown): id is PropertyId {
-  return typeof id === 'string' && /^P[1-9][0-9]*$/.test(id)
-}
-
-export function isLexemeId (id: unknown): id is LexemeId {
-  return typeof id === 'string' && /^L[1-9][0-9]*$/.test(id)
-}
-
-export function isFormId (id: unknown): id is FormId {
-  return typeof id === 'string' && /^L[1-9][0-9]*-F[1-9][0-9]*$/.test(id)
-}
-
-export function isSenseId (id: unknown): id is SenseId {
-  return typeof id === 'string' && /^L[1-9][0-9]*-S[1-9][0-9]*$/.test(id)
-}
-
-export function isGuid (guid: unknown): guid is Guid {
-  return typeof guid === 'string' &&
-    /^((Q|P|L)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)\$[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-      .test(guid)
-}
-
-export function isHash (hash: unknown): hash is Hash {
-  return typeof hash === 'string' && /^[0-9a-f]{40}$/.test(hash)
-}
-
-export function isPropertyClaimsId (id: unknown): id is PropertyClaimsId {
+export function isPropertyClaimsId (id: string): id is PropertyClaimsId {
   if (typeof id !== 'string') return false
   const [ entityId, propertyId ] = id.split('#')
   return isEntityId(entityId) && isPropertyId(propertyId)
 }
 
-export function isRevisionId (id: unknown): id is RevisionId {
-  return typeof id === 'string' && /^\d+$/.test(id)
-}
-
-export function isEntityPageTitle (title: unknown): title is EntityPageTitle {
+export function isEntityPageTitle (title: string): title is EntityPageTitle {
   if (typeof title !== 'string') return false
 
   if (title.startsWith('Item:')) {
@@ -88,11 +58,7 @@ export function isEntityPageTitle (title: unknown): title is EntityPageTitle {
   return isItemId(title)
 }
 
-function isNonNestedEntityId (id: unknown): id is NonNestedEntityId {
-  return typeof id === 'string' && /^(Q|P|L)[1-9][0-9]*$/.test(id)
-}
-
-export function getNumericId (id: unknown): NumericId {
+export function getNumericId (id: string): NumericId {
   if (!isNonNestedEntityId(id)) throw new Error(`invalid entity id: ${id}`)
   return id.replace(/^(Q|P|L)/, '') as NumericId
 }

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -8,6 +8,7 @@ import type {
   Hash,
   ItemId,
   LexemeId,
+  MediaInfoId,
   NonNestedEntityId,
   NumericId,
   PropertyClaimsId,
@@ -29,10 +30,11 @@ export const isPropertyId = isIdBuilder<PropertyId>(/^P[1-9][0-9]*$/)
 export const isLexemeId = isIdBuilder<LexemeId>(/^L[1-9][0-9]*$/)
 export const isFormId = isIdBuilder<FormId>(/^L[1-9][0-9]*-F[1-9][0-9]*$/)
 export const isSenseId = isIdBuilder<SenseId>(/^L[1-9][0-9]*-S[1-9][0-9]*$/)
-export const isGuid = isIdBuilder<Guid>(/^((Q|P|L)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)\$[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+export const isMediaInfoId = isIdBuilder<MediaInfoId>(/^M[1-9][0-9]*$/)
+export const isGuid = isIdBuilder<Guid>(/^((Q|P|L|M)[1-9][0-9]*|L[1-9][0-9]*-(F|S)[1-9][0-9]*)\$[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
 export const isHash = isIdBuilder<Hash>(/^[0-9a-f]{40}$/)
 export const isRevisionId = isIdBuilder<RevisionId>(/^\d+$/)
-export const isNonNestedEntityId = isIdBuilder<NonNestedEntityId>(/^(Q|P|L)[1-9][0-9]*$/)
+export const isNonNestedEntityId = isIdBuilder<NonNestedEntityId>(/^(Q|P|L|M)[1-9][0-9]*$/)
 
 export function isPropertyClaimsId (id: string): id is PropertyClaimsId {
   if (typeof id !== 'string') return false
@@ -60,7 +62,7 @@ export function isEntityPageTitle (title: string): title is EntityPageTitle {
 
 export function getNumericId (id: string): NumericId {
   if (!isNonNestedEntityId(id)) throw new Error(`invalid entity id: ${id}`)
-  return id.replace(/^(Q|P|L)/, '') as NumericId
+  return id.replace(/^(Q|P|L|M)/, '') as NumericId
 }
 
 export interface WikibaseTimeObject {

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -79,7 +79,7 @@ function bestEffort<T> (fn: TimeFunction<T>) {
   return (value: TimeInputValue) => {
     try {
       return fn(value)
-    } catch (err) {
+    } catch {
       value = typeof value === 'string' ? value : value.time
 
       const sign = value[0]

--- a/src/helpers/parse_claim.ts
+++ b/src/helpers/parse_claim.ts
@@ -1,4 +1,5 @@
 import { wikibaseTimeToISOString, wikibaseTimeToEpochTime, wikibaseTimeToSimpleDay } from './helpers.js'
+import type { TimeInputValue } from './helpers.js'
 
 const simple = datavalue => datavalue.value
 
@@ -12,7 +13,7 @@ const entityLetter = {
   item: 'Q',
   lexeme: 'L',
   property: 'P',
-}
+} as const
 
 const prefixedId = (datavalue, prefix) => {
   const { value } = datavalue
@@ -73,8 +74,8 @@ export const timeConverters = {
   iso: wikibaseTimeToISOString,
   epoch: wikibaseTimeToEpochTime,
   'simple-day': wikibaseTimeToSimpleDay,
-  none: wikibaseTime => wikibaseTime.time || wikibaseTime,
-}
+  none: (wikibaseTime: TimeInputValue) => typeof wikibaseTime === 'string' ? wikibaseTime : wikibaseTime.time,
+} as const
 
 export const parsers = {
   commonsMedia: simple,
@@ -95,7 +96,7 @@ export const parsers = {
   'wikibase-lexeme': entity,
   'wikibase-property': entity,
   'wikibase-sense': entity,
-}
+} as const
 
 export function parseClaim (datatype, datavalue, options, claimId) {
   // Known case of missing datatype: form.claims, sense.claims

--- a/src/helpers/parse_responses.ts
+++ b/src/helpers/parse_responses.ts
@@ -18,19 +18,17 @@ export interface CirrusSearchPagesResponse {
   }
 }
 
-export const parse = {
-  entities: (res: WbGetEntitiesResponse): SimplifiedEntities => {
-    // Legacy convenience for the time the 'request' lib was all the rage
-    // @ts-ignore
-    res = res.body || res
-    const { entities } = res
-    return simplifyEntities(entities)
-  },
-
-  pagesTitles: (res: CirrusSearchPagesResponse): Titles => {
-    // Same behavior as above
-    // @ts-ignore
-    res = res.body || res
-    return res.query.search.map(result => result.title)
-  },
+function entities (res: WbGetEntitiesResponse): SimplifiedEntities {
+  // @ts-expect-error Legacy convenience for the time the 'request' lib was all the rage
+  res = res.body || res
+  const { entities } = res
+  return simplifyEntities(entities)
 }
+
+function pagesTitles (res: CirrusSearchPagesResponse): Titles {
+  // @ts-expect-error Same behavior as above
+  res = res.body || res
+  return res.query.search.map(result => result.title)
+}
+
+export const parse = { entities, pagesTitles } as const

--- a/src/helpers/simplify.ts
+++ b/src/helpers/simplify.ts
@@ -16,8 +16,8 @@ import {
   simplifySense as sense,
   simplifySenses as senses,
 } from './simplify_senses.js'
-import sitelinks from './simplify_sitelinks.js'
-import { simplifySparqlResults } from './simplify_sparql_results.js'
+import { simplifySitelinks as sitelinks } from './simplify_sitelinks.js'
+import { simplifySparqlResults as sparqlResults } from './simplify_sparql_results.js'
 import {
   simplifyLabels as labels,
   simplifyDescriptions as descriptions,
@@ -54,7 +54,7 @@ export const simplify = {
   sense,
   senses,
 
-  sparqlResults: simplifySparqlResults,
+  sparqlResults,
 
   // Set in ./simplify_entity
   // entity,

--- a/src/helpers/simplify_claims.ts
+++ b/src/helpers/simplify_claims.ts
@@ -6,7 +6,7 @@ import type { SimplifiedClaim, SimplifiedClaims, SimplifiedPropertyClaims, Simpl
 
 function simplifySnaks (snaks, options) {
   const { propertyPrefix } = options
-  const simplifiedSnaks = {}
+  const simplifiedSnaks: any = {}
   for (let id in snaks) {
     const propertySnaks = snaks[id]
     if (propertyPrefix) {
@@ -35,7 +35,8 @@ function simplifyPropertySnaks (propertySnaks, options) {
     .map(claim => simplifyClaim(claim, options))
     // Filter-out novalue and somevalue claims,
     // unless a novalueValue or a somevalueValue is passed in options
-    .filter(isDefined)
+    // Considers null as defined
+    .filter(obj => obj !== undefined)
 
   // Deduplicate values unless we return a rich value object
   if (propertySnaks[0] && typeof propertySnaks[0] !== 'object') {
@@ -44,9 +45,6 @@ function simplifyPropertySnaks (propertySnaks, options) {
     return propertySnaks
   }
 }
-
-// Considers null as defined
-const isDefined = obj => obj !== undefined
 
 // Expects a single snak object
 // Ex: entity.claims.P369[0]

--- a/src/helpers/simplify_entity.ts
+++ b/src/helpers/simplify_entity.ts
@@ -41,10 +41,10 @@ const simplifyIfDefined = (entity, simplified, attribute, options?) => {
 }
 
 export const simplifyEntities = (entities: Entities, options: SimplifyEntityOptions = {}) => {
-  // @ts-ignore
+  // @ts-expect-error
   if (entities.entities) entities = entities.entities
   const { entityPrefix } = options
-  return Object.keys(entities).reduce((obj, key) => {
+  return Object.keys(entities).reduce<any>((obj, key) => {
     const entity = entities[key]
     if (entityPrefix) key = `${entityPrefix}:${key}`
     obj[key] = simplifyEntity(entity, options)
@@ -53,7 +53,7 @@ export const simplifyEntities = (entities: Entities, options: SimplifyEntityOpti
 }
 
 // Set those here instead of in ./simplify to avoid a circular dependency
-// @ts-ignore
+// @ts-expect-error
 simplify.entity = simplifyEntity
-// @ts-ignore
+// @ts-expect-error
 simplify.entities = simplifyEntities

--- a/src/helpers/simplify_senses.ts
+++ b/src/helpers/simplify_senses.ts
@@ -4,7 +4,7 @@ import { simplifyGlosses } from './simplify_text_attributes.js'
 import type { Sense, SimplifiedSense } from '../types/lexeme.js'
 import type { SimplifyClaimsOptions } from '../types/simplify_claims.js'
 
-export const simplifySense = (sense: Sense, options: SimplifyClaimsOptions): SimplifiedSense => {
+export const simplifySense = (sense: Sense, options: SimplifyClaimsOptions = {}): SimplifiedSense => {
   const { id, glosses, claims } = sense
   if (!isSenseId(id)) throw new Error('invalid sense object')
   return {
@@ -14,4 +14,6 @@ export const simplifySense = (sense: Sense, options: SimplifyClaimsOptions): Sim
   }
 }
 
-export const simplifySenses = (senses, options) => senses.map(sense => simplifySense(sense, options))
+export function simplifySenses (senses: readonly Sense[], options: SimplifyClaimsOptions = {}) {
+  return senses.map(sense => simplifySense(sense, options))
+}

--- a/src/helpers/simplify_sitelinks.ts
+++ b/src/helpers/simplify_sitelinks.ts
@@ -2,7 +2,7 @@ import { getSitelinkUrl } from './sitelinks.js'
 import type { SimplifySitelinkOptions } from '../types/options.js'
 import type { SimplifiedSitelinks, Sitelinks } from '../types/sitelinks.js'
 
-export default (sitelinks: Sitelinks, options: SimplifySitelinkOptions = {}): SimplifiedSitelinks => {
+export function simplifySitelinks (sitelinks: Sitelinks, options: SimplifySitelinkOptions = {}): SimplifiedSitelinks {
   let { addUrl, keepBadges, keepAll } = options
   keepBadges = keepBadges || keepAll
   return Object.keys(sitelinks).reduce(aggregateValues({

--- a/src/helpers/simplify_sparql_results.ts
+++ b/src/helpers/simplify_sparql_results.ts
@@ -122,4 +122,4 @@ const addAssociatedValue = (result, varName, associatedVarName, richVarData) => 
 
 const specialNames = {
   altLabel: 'aliases',
-}
+} as const

--- a/src/helpers/validate.ts
+++ b/src/helpers/validate.ts
@@ -1,12 +1,13 @@
 import { isEntityId, isEntityPageTitle, isPropertyId, isRevisionId } from './helpers.js'
 
-const validate = (name, testFn) => value => {
-  if (!testFn(value)) throw new Error(`invalid ${name}: ${value}`)
+function validate<T> (name: string, testFn: (value: unknown) => value is T) {
+  return function (value: unknown): value is T {
+    if (!testFn(value)) throw new Error(`invalid ${name}: ${value}`)
+    return true
+  }
 }
 
-export default {
-  entityId: validate('entity id', isEntityId),
-  propertyId: validate('property id', isPropertyId),
-  entityPageTitle: validate('entity page title', isEntityPageTitle),
-  revisionId: validate('revision id', isRevisionId),
-}
+export const entityId = validate('entity id', isEntityId)
+export const propertyId = validate('property id', isPropertyId)
+export const entityPageTitle = validate('entity page title', isEntityPageTitle)
+export const revisionId = validate('revision id', isRevisionId)

--- a/src/helpers/validate.ts
+++ b/src/helpers/validate.ts
@@ -1,9 +1,9 @@
 import { isEntityId, isEntityPageTitle, isPropertyId, isRevisionId } from './helpers.js'
 
-function validate<T> (name: string, testFn: (value: unknown) => value is T) {
-  return function (value: unknown): value is T {
+/** Ensure both via TypeScript and at runtime that the input value is of the expected type. Throws error when it is not */
+function validate<T extends string> (name: string, testFn: (value: string) => value is T) {
+  return function (value: T): void {
     if (!testFn(value)) throw new Error(`invalid ${name}: ${value}`)
-    return true
   }
 }
 

--- a/src/helpers/wikibase_time_to_date_object.ts
+++ b/src/helpers/wikibase_time_to_date_object.ts
@@ -17,15 +17,15 @@ export function wikibaseTimeToDateObject (wikibaseTime: TimeInputValue): Date {
   return fullDateData(sign, rest)
 }
 
-const fullDateData = (sign, rest) => {
+const fullDateData = (sign: string, rest: string) => {
   const year = rest.split('-')[0]
   const needsExpandedYear = sign === '-' || year.length > 4
 
   return needsExpandedYear ? expandedYearDate(sign, rest, year) : new Date(rest)
 }
 
-const expandedYearDate = (sign, rest, year) => {
-  let date
+const expandedYearDate = (sign: string, rest: string, year: string) => {
+  let date: string
   // Using ISO8601 expanded notation for negative years or positive
   // years with more than 4 digits: adding up to 2 leading zeros
   // when needed. Can't find the documentation again, but testing

--- a/src/queries/get_entities.ts
+++ b/src/queries/get_entities.ts
@@ -1,11 +1,12 @@
 import * as validate from '../helpers/validate.js'
 import { forceArray, rejectObsoleteInterface, shortLang } from '../utils/utils.js'
+import type { EntityId } from '../types/entity.js'
 import type { Props, Url, UrlResultFormat, WmLanguageCode } from '../types/options.js'
 import type { WbGetEntities } from '../types/wbgetentities.js'
 import type { BuildUrlFunction } from '../utils/build_url.js'
 
 export interface GetEntitiesOptions {
-  ids: string | string[]
+  ids: EntityId | EntityId[]
   languages?: WmLanguageCode | WmLanguageCode[]
   props?: Props | Props[]
   format?: UrlResultFormat
@@ -28,7 +29,7 @@ export function getEntitiesFactory (buildUrl: BuildUrlFunction) {
     // Allow to pass ids as a single string
     ids = forceArray(ids)
 
-    ids.forEach(validate.entityId)
+    ids.forEach(o => validate.entityId(o))
 
     if (ids.length > 50) {
       console.warn(`getEntities accepts 50 ids max to match Wikidata API limitations:

--- a/src/queries/get_entities.ts
+++ b/src/queries/get_entities.ts
@@ -1,4 +1,4 @@
-import validate from '../helpers/validate.js'
+import * as validate from '../helpers/validate.js'
 import { forceArray, rejectObsoleteInterface, shortLang } from '../utils/utils.js'
 import type { Props, Url, UrlResultFormat, WmLanguageCode } from '../types/options.js'
 import type { WbGetEntities } from '../types/wbgetentities.js'

--- a/src/queries/get_entities_from_sitelinks.ts
+++ b/src/queries/get_entities_from_sitelinks.ts
@@ -34,7 +34,6 @@ export function getEntitiesFromSitelinksFactory (buildUrl: BuildUrlFunction) {
     // either case me just want to deal with arrays
     titles = forceArray(titles)
     sites = forceArray(sites).map(parseSite)
-    // @ts-ignore
     props = forceArray(props)
 
     const query: WbGetEntities = {
@@ -54,7 +53,7 @@ export function getEntitiesFromSitelinksFactory (buildUrl: BuildUrlFunction) {
       query.languages = languages.join('|')
     }
 
-    if (props && props.length > 0 && typeof props === 'object') {
+    if (props.length > 0) {
       query.props = props.join('|')
     }
 

--- a/src/queries/get_entities_from_sitelinks.ts
+++ b/src/queries/get_entities_from_sitelinks.ts
@@ -1,4 +1,5 @@
-import { forceArray, shortLang, rejectObsoleteInterface } from '../utils/utils.js'
+import { languages } from '../helpers/sitelinks_languages.js'
+import { forceArray, shortLang, rejectObsoleteInterface, isOfType } from '../utils/utils.js'
 import type { Props, Url, UrlResultFormat, WmLanguageCode } from '../types/options.js'
 import type { Site } from '../types/sitelinks.js'
 import type { WbGetEntities } from '../types/wbgetentities.js'
@@ -63,5 +64,13 @@ export function getEntitiesFromSitelinksFactory (buildUrl: BuildUrlFunction) {
   }
 }
 
-// convert 2 letters language code to Wikipedia sitelinks code
-const parseSite = (site: string) => (site.length === 2 ? `${site}wiki` : site)
+/** convert language code to Wikipedia sitelink code */
+function parseSite (site: Site | WmLanguageCode): Site {
+  if (isOfType(languages, site)) {
+    // The `as Site` conversion shouldnt be needed but WmLanguageCode and Site do not seem to be perfectly in sync?
+    // Both are created by scripts so this is also out of sync on the Wikimedia projects?
+    return `${site}wiki` as Site
+  } else {
+    return site
+  }
+}

--- a/src/queries/get_entity_revision.ts
+++ b/src/queries/get_entity_revision.ts
@@ -1,14 +1,14 @@
-import validate from '../helpers/validate.js'
+import * as validate from '../helpers/validate.js'
 import { rejectObsoleteInterface } from '../utils/utils.js'
-import type { EntityId } from '../types/entity.js'
+import type { EntityId, RevisionId } from '../types/entity.js'
 import type { Url } from '../types/options.js'
 
 export interface GetEntityRevisionOptions {
   id: EntityId
-  revision: `${number}`
+  revision: RevisionId
 }
 
-export function getEntityRevisionFactory (instance, wgScriptPath) {
+export function getEntityRevisionFactory (instance: Url, wgScriptPath: string) {
   return function getEntityRevision ({ id, revision }: GetEntityRevisionOptions): Url {
     rejectObsoleteInterface(arguments)
     validate.entityId(id)

--- a/src/queries/get_many_entities.ts
+++ b/src/queries/get_many_entities.ts
@@ -13,17 +13,17 @@ export function getManyEntitiesFactory (buildUrl: BuildUrlFunction) {
   return function getManyEntities ({ ids, languages, props, format, redirects }: GetManyEntitiesOptions): Url[] {
     rejectObsoleteInterface(arguments)
     if (!(ids instanceof Array)) throw new Error('getManyEntities expects an array of ids')
-    return getIdsGroups(ids)
-    .map(idsGroup => getEntities({ ids: idsGroup, languages, props, format, redirects }))
+    return getChunks(ids)
+      .map(idsGroup => getEntities({ ids: idsGroup, languages, props, format, redirects }))
   }
 }
 
-const getIdsGroups = ids => {
-  const groups = []
+function getChunks (ids: readonly string[]): string[][] {
+  const chunks = []
   while (ids.length > 0) {
-    const group = ids.slice(0, 50)
+    const chunk = ids.slice(0, 50)
     ids = ids.slice(50)
-    groups.push(group)
+    chunks.push(chunk)
   }
-  return groups
+  return chunks
 }

--- a/src/queries/get_many_entities.ts
+++ b/src/queries/get_many_entities.ts
@@ -1,11 +1,12 @@
 import { rejectObsoleteInterface } from '../utils/utils.js'
 import { getEntitiesFactory } from './get_entities.js'
 import type { GetEntitiesOptions } from './get_entities.js'
+import type { EntityId } from '../types/entity.js'
 import type { Url } from '../types/options.js'
 import type { BuildUrlFunction } from '../utils/build_url.js'
 
 export interface GetManyEntitiesOptions extends GetEntitiesOptions {
-  ids: string[]
+  ids: EntityId[]
 }
 
 export function getManyEntitiesFactory (buildUrl: BuildUrlFunction) {
@@ -18,7 +19,7 @@ export function getManyEntitiesFactory (buildUrl: BuildUrlFunction) {
   }
 }
 
-function getChunks (ids: readonly string[]): string[][] {
+function getChunks<T extends string> (ids: readonly T[]): T[][] {
   const chunks = []
   while (ids.length > 0) {
     const chunk = ids.slice(0, 50)

--- a/src/queries/get_reverse_claims.ts
+++ b/src/queries/get_reverse_claims.ts
@@ -28,7 +28,7 @@ export const getReverseClaimsFactory = (sparqlEndpoint: Url) => {
 
     // Allow to request values for several properties at once
     properties = forceArray(properties)
-    properties.forEach(validate.propertyId)
+    properties.forEach(o => validate.propertyId(o))
 
     const valueBlock = getValueBlock(values, valueFn, properties, filter)
     let sparql = `SELECT DISTINCT ?subject WHERE { ${valueBlock} }`

--- a/src/queries/get_reverse_claims.ts
+++ b/src/queries/get_reverse_claims.ts
@@ -1,5 +1,5 @@
 import { isItemId } from '../helpers/helpers.js'
-import validate from '../helpers/validate.js'
+import * as validate from '../helpers/validate.js'
 import { forceArray } from '../utils/utils.js'
 import { sparqlQueryFactory } from './sparql_query.js'
 import type { PropertyId } from '../types/entity.js'
@@ -18,7 +18,7 @@ export interface GetReverseClaimsOptions {
   keepProperties?: boolean
 }
 
-export const getReverseClaimsFactory = sparqlEndpoint => {
+export const getReverseClaimsFactory = (sparqlEndpoint: Url) => {
   const sparqlQuery = sparqlQueryFactory(sparqlEndpoint)
   return function getReverseClaims (options: GetReverseClaimsOptions): Url {
     let { properties } = options
@@ -27,9 +27,7 @@ export const getReverseClaimsFactory = sparqlEndpoint => {
     const filter = keepProperties ? '' : itemsOnly
 
     // Allow to request values for several properties at once
-    // @ts-ignore
     properties = forceArray(properties)
-    // @ts-ignore
     properties.forEach(validate.propertyId)
 
     const valueBlock = getValueBlock(values, valueFn, properties, filter)

--- a/src/queries/get_revisions.ts
+++ b/src/queries/get_revisions.ts
@@ -1,14 +1,14 @@
 import * as validate from '../helpers/validate.js'
 import { forceArray, rejectObsoleteInterface } from '../utils/utils.js'
 import type { EntityPageTitle } from '../types/entity.js'
+import type { ApiQueryParameters, UrlResultFormat } from '../types/options.js'
 import type { BuildUrlFunction } from '../utils/build_url.js'
-import type { URLFormatOptions } from 'url'
 
 // See https://www.wikidata.org/w/api.php?action=help&modules=query+revisions
 
 export interface GetRevisionsOptions {
   ids: EntityPageTitle | EntityPageTitle[]
-  format?: URLFormatOptions
+  format?: UrlResultFormat
   limit?: number
   start?: Date | string | number
   end?: Date | string | number
@@ -25,7 +25,7 @@ export function getRevisionsFactory (buildUrl: BuildUrlFunction) {
     ids.forEach(validate.entityPageTitle)
 
     const uniqueId = ids.length === 1
-    const query: any = {
+    const query: ApiQueryParameters = {
       action: 'query',
       prop: 'revisions',
     }

--- a/src/queries/get_revisions.ts
+++ b/src/queries/get_revisions.ts
@@ -22,7 +22,7 @@ export function getRevisionsFactory (buildUrl: BuildUrlFunction) {
   return function getRevisions ({ ids, format, limit, start, end, prop, user, excludeuser, tag }: GetRevisionsOptions) {
     rejectObsoleteInterface(arguments)
     ids = forceArray(ids)
-    ids.forEach(validate.entityPageTitle)
+    ids.forEach(o => validate.entityPageTitle(o))
 
     const uniqueId = ids.length === 1
     const query: ApiQueryParameters = {

--- a/src/queries/get_revisions.ts
+++ b/src/queries/get_revisions.ts
@@ -1,13 +1,13 @@
-import validate from '../helpers/validate.js'
+import * as validate from '../helpers/validate.js'
 import { forceArray, rejectObsoleteInterface } from '../utils/utils.js'
-import type { EntityId, NamedspacedEntityId } from '../types/entity.js'
+import type { EntityPageTitle } from '../types/entity.js'
 import type { BuildUrlFunction } from '../utils/build_url.js'
 import type { URLFormatOptions } from 'url'
 
 // See https://www.wikidata.org/w/api.php?action=help&modules=query+revisions
 
 export interface GetRevisionsOptions {
-  ids: EntityId | EntityId[] | NamedspacedEntityId | NamedspacedEntityId[]
+  ids: EntityPageTitle | EntityPageTitle[]
   format?: URLFormatOptions
   limit?: number
   start?: Date | string | number
@@ -21,9 +21,7 @@ export interface GetRevisionsOptions {
 export function getRevisionsFactory (buildUrl: BuildUrlFunction) {
   return function getRevisions ({ ids, format, limit, start, end, prop, user, excludeuser, tag }: GetRevisionsOptions) {
     rejectObsoleteInterface(arguments)
-    // @ts-ignore
     ids = forceArray(ids)
-    // @ts-ignore
     ids.forEach(validate.entityPageTitle)
 
     const uniqueId = ids.length === 1
@@ -32,7 +30,6 @@ export function getRevisionsFactory (buildUrl: BuildUrlFunction) {
       prop: 'revisions',
     }
 
-    // @ts-ignore
     query.titles = ids.join('|')
     query.format = format || 'json'
     if (uniqueId) query.rvlimit = limit || 'max'
@@ -53,7 +50,7 @@ export function getRevisionsFactory (buildUrl: BuildUrlFunction) {
   }
 }
 
-const getEpochSeconds = date => {
+const getEpochSeconds = (date: string | number | Date) => {
   // Return already formatted epoch seconds:
   // if a date in milliseconds appear to be earlier than 2000-01-01, that's probably
   // already seconds actually

--- a/src/queries/search_entities.ts
+++ b/src/queries/search_entities.ts
@@ -1,9 +1,8 @@
-import { rejectObsoleteInterface } from '../utils/utils.js'
+import { EntityTypes } from '../types/entity.js'
+import { isOfType, rejectObsoleteInterface } from '../utils/utils.js'
 import type { EntityType } from '../types/entity.js'
 import type { Url, UrlResultFormat } from '../types/options.js'
 import type { BuildUrlFunction } from '../utils/build_url.js'
-
-const types = [ 'item', 'property', 'lexeme', 'form', 'sense' ]
 
 export interface SearchEntitiesOptions {
   search: string
@@ -29,7 +28,7 @@ export const searchEntitiesFactory = (buildUrl: BuildUrlFunction) => {
     uselang = uselang || language
 
     if (!(search && search.length > 0)) throw new Error("search can't be empty")
-    if (!types.includes(type)) throw new Error(`invalid type: ${type}`)
+    if (!isOfType(EntityTypes, type)) throw new Error(`invalid type: ${type}`)
 
     return buildUrl({
       action: 'wbsearchentities',

--- a/src/types/entity.ts
+++ b/src/types/entity.ts
@@ -14,12 +14,13 @@ export type LexemeId = `L${number}`
 export type FormId = `L${number}-F${number}`
 export type SenseId = `L${number}-S${number}`
 export type EntitySchemaId = `E${number}`
+export type MediaInfoId = `M${number}`
 export type RevisionId = `${number}`
 
 export type PropertyClaimsId = `${EntityId}#${PropertyId}`
 
 export type EntityId = NonNestedEntityId | FormId | SenseId
-export type NonNestedEntityId = ItemId | PropertyId | LexemeId
+export type NonNestedEntityId = ItemId | PropertyId | LexemeId | MediaInfoId
 export type NamespacedEntityId = `Item:${ItemId}` | `Lexeme:${LexemeId}` | `Property:${PropertyId}`
 
 export type Guid = string

--- a/src/types/entity.ts
+++ b/src/types/entity.ts
@@ -4,20 +4,29 @@ import type { SimplifiedClaims } from './simplify_claims.js'
 import type { SimplifiedSitelinks, Sitelinks } from './sitelinks.js'
 import type { Aliases, Descriptions, Labels, Lemmas, SimplifiedAliases, SimplifiedDescriptions, SimplifiedLabels, SimplifiedLemmas } from './terms.js'
 
-export type EntityType = 'item' | 'property' | 'lexeme' | 'form' | 'sense'
+export const EntityTypes = [ 'item', 'property', 'lexeme', 'form', 'sense' ] as const
+export type EntityType = typeof EntityTypes[number]
 
+export type NumericId = `${number}`
 export type ItemId = `Q${number}`
 export type PropertyId = `P${number}`
 export type LexemeId = `L${number}`
 export type FormId = `L${number}-F${number}`
 export type SenseId = `L${number}-S${number}`
-export type EntityId = ItemId | PropertyId | LexemeId
+export type EntitySchemaId = `E${number}`
+export type RevisionId = `${number}`
 
-export type NamedspacedEntityId = `${string}:${EntityId}`
+export type PropertyClaimsId = `${EntityId}#${PropertyId}`
+
+export type EntityId = NonNestedEntityId | FormId | SenseId
+export type NonNestedEntityId = ItemId | PropertyId | LexemeId
+export type NamespacedEntityId = `Item:${ItemId}` | `Lexeme:${LexemeId}` | `Property:${PropertyId}`
 
 export type Guid = string
+export type Hash = string
 
 export type Entity = (Property | Item | Lexeme)
+export type EntityPageTitle = NamespacedEntityId | ItemId
 export type Entities = Record<EntityId, Entity>
 
 export interface Property extends EntityInfo {
@@ -75,7 +84,7 @@ export interface SimplifiedItem extends SimplifiedEntityInfo {
 }
 
 export interface SimplifiedProperty extends SimplifiedEntityInfo {
-  type: 'item',
+  type: 'property',
   datatype: DataType,
   labels?: SimplifiedLabels
   descriptions?: SimplifiedDescriptions
@@ -85,7 +94,7 @@ export interface SimplifiedProperty extends SimplifiedEntityInfo {
 }
 
 export interface SimplifiedLexeme extends SimplifiedEntityInfo {
-  type: 'item',
+  type: 'lexeme',
   lexicalCategory: ItemId
   language: ItemId
   lemmas?: SimplifiedLemmas

--- a/src/types/sitelinks.ts
+++ b/src/types/sitelinks.ts
@@ -14,6 +14,6 @@ export interface Sitelink {
   url?: Url
 }
 
-export type Sitelinks = Record<Site, Sitelink>
+export type Sitelinks = Partial<Record<Site, Sitelink>>
 
-export type SimplifiedSitelinks = Record<Site, string>
+export type SimplifiedSitelinks = Partial<Record<Site, string>>

--- a/src/types/wbk.ts
+++ b/src/types/wbk.ts
@@ -73,20 +73,20 @@ export interface Wbk {
   // Helpers
   getEntityIdFromGuid (guid: Guid): EntityId
   getImageUrl (filename: string, width?: number): Url
-  getNumericId (s: unknown): NumericId
-  isEntityId (s: unknown): s is EntityId
-  isEntityPageTitle (s: unknown): s is EntityPageTitle
-  isEntitySchemaId (s: unknown): s is EntitySchemaId
-  isFormId (s: unknown): s is FormId
-  isGuid (s: unknown): s is Guid
-  isHash (s: unknown): s is Hash
-  isItemId (s: unknown): s is ItemId
-  isLexemeId (s: unknown): s is LexemeId
-  isNumericId (s: unknown): s is NumericId
-  isPropertyClaimsId (s: unknown): s is PropertyClaimsId
-  isPropertyId (s: unknown): s is PropertyId
-  isRevisionId (s: unknown): s is RevisionId
-  isSenseId (s: unknown): s is SenseId
+  getNumericId (s: string): NumericId
+  isEntityId (s: string): s is EntityId
+  isEntityPageTitle (s: string): s is EntityPageTitle
+  isEntitySchemaId (s: string): s is EntitySchemaId
+  isFormId (s: string): s is FormId
+  isGuid (s: string): s is Guid
+  isHash (s: string): s is Hash
+  isItemId (s: string): s is ItemId
+  isLexemeId (s: string): s is LexemeId
+  isNumericId (s: string): s is NumericId
+  isPropertyClaimsId (s: string): s is PropertyClaimsId
+  isPropertyId (s: string): s is PropertyId
+  isRevisionId (s: string): s is RevisionId
+  isSenseId (s: string): s is SenseId
 
   wikibaseTimeToEpochTime (wikibaseTime: TimeInputValue): number
   wikibaseTimeToISOString (wikibaseTime: TimeInputValue): string

--- a/src/types/wbk.ts
+++ b/src/types/wbk.ts
@@ -1,5 +1,5 @@
 import type { Claim, Claims, PropertyClaims, PropertyQualifiers, PropertySnaks, Qualifier, Qualifiers, References, Snak, Snaks } from './claim.js'
-import type { Entities, Entity, EntityId, EntityPageTitle, EntitySchemaId, FormId, Guid, Hash, ItemId, LexemeId, NumericId, PropertyClaimsId, PropertyId, RevisionId, SenseId, SimplifiedEntities, SimplifiedEntity } from './entity.js'
+import type { Entities, Entity, EntityId, EntityPageTitle, EntitySchemaId, FormId, Guid, Hash, ItemId, LexemeId, MediaInfoId, NumericId, PropertyClaimsId, PropertyId, RevisionId, SenseId, SimplifiedEntities, SimplifiedEntity } from './entity.js'
 import type { Form, Forms, Sense, Senses, SimplifiedForm, SimplifiedForms, SimplifiedSense, SimplifiedSenses } from './lexeme.js'
 import type { SimplifyEntityOptions, Url } from './options.js'
 import type { SimplifiedClaim, SimplifiedClaims, SimplifiedPropertyClaims, SimplifiedPropertyQualifiers, SimplifiedQualifier, SimplifiedQualifiers } from './simplify_claims.js'
@@ -82,6 +82,7 @@ export interface Wbk {
   isHash (s: string): s is Hash
   isItemId (s: string): s is ItemId
   isLexemeId (s: string): s is LexemeId
+  isMediaInfoId (s: string): s is MediaInfoId
   isNumericId (s: string): s is NumericId
   isPropertyClaimsId (s: string): s is PropertyClaimsId
   isPropertyId (s: string): s is PropertyId

--- a/src/types/wbk.ts
+++ b/src/types/wbk.ts
@@ -1,5 +1,5 @@
 import type { Claim, Claims, PropertyClaims, PropertyQualifiers, PropertySnaks, Qualifier, Qualifiers, References, Snak, Snaks } from './claim.js'
-import type { Entities, Entity, EntityId, Guid, SimplifiedEntities, SimplifiedEntity } from './entity.js'
+import type { Entities, Entity, EntityId, EntityPageTitle, EntitySchemaId, FormId, Guid, Hash, ItemId, LexemeId, NumericId, PropertyClaimsId, PropertyId, RevisionId, SenseId, SimplifiedEntities, SimplifiedEntity } from './entity.js'
 import type { Form, Forms, Sense, Senses, SimplifiedForm, SimplifiedForms, SimplifiedSense, SimplifiedSenses } from './lexeme.js'
 import type { SimplifyEntityOptions, Url } from './options.js'
 import type { SimplifiedClaim, SimplifiedClaims, SimplifiedPropertyClaims, SimplifiedPropertyQualifiers, SimplifiedQualifier, SimplifiedQualifiers } from './simplify_claims.js'
@@ -73,20 +73,20 @@ export interface Wbk {
   // Helpers
   getEntityIdFromGuid (guid: Guid): EntityId
   getImageUrl (filename: string, width?: number): Url
-  getNumericId (id: string): string
-  isEntityId (str: string): boolean
-  isEntityPageTitle (str: string): boolean
-  isEntitySchemaId (str: string): boolean
-  isFormId (str: string): boolean
-  isGuid (str: string): boolean
-  isHash (str: string): boolean
-  isItemId (str: string): boolean
-  isLexemeId (str: string): boolean
-  isNumericId (str: string): boolean
-  isPropertyClaimsId (str: string): boolean
-  isPropertyId (str: string): boolean
-  isRevisionId (str: string): boolean
-  isSenseId (str: string): boolean
+  getNumericId (s: unknown): NumericId
+  isEntityId (s: unknown): s is EntityId
+  isEntityPageTitle (s: unknown): s is EntityPageTitle
+  isEntitySchemaId (s: unknown): s is EntitySchemaId
+  isFormId (s: unknown): s is FormId
+  isGuid (s: unknown): s is Guid
+  isHash (s: unknown): s is Hash
+  isItemId (s: unknown): s is ItemId
+  isLexemeId (s: unknown): s is LexemeId
+  isNumericId (s: unknown): s is NumericId
+  isPropertyClaimsId (s: unknown): s is PropertyClaimsId
+  isPropertyId (s: unknown): s is PropertyId
+  isRevisionId (s: unknown): s is RevisionId
+  isSenseId (s: unknown): s is SenseId
 
   wikibaseTimeToEpochTime (wikibaseTime: TimeInputValue): number
   wikibaseTimeToISOString (wikibaseTime: TimeInputValue): string

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,22 +1,31 @@
 import type { WmLanguageCode } from '../types/options.js'
 
-// Ex: keep only 'fr' in 'fr_FR'
+/** Example: keep only 'fr' in 'fr_FR' */
 export function shortLang (language: string): WmLanguageCode {
   const lang = language.toLowerCase().split('_')[0] as WmLanguageCode
   return lang
 }
 
-// a polymorphism helper:
-// accept either a string or an array and return an array
-export function forceArray (array): string[] {
-  if (typeof array === 'string') array = [ array ]
-  return array || []
+/**
+ * a polymorphism helper:
+ * accept either a string or an array and return an array
+ */
+export function forceArray<T extends string> (array: T | readonly T[] | undefined): T[] {
+  if (typeof array === 'string') {
+    return [ array ]
+  }
+
+  if (Array.isArray(array)) {
+    // TODO: return readonly array
+    return [ ...array ]
+  }
+
+  return []
 }
 
-// simplistic implementation to filter-out arrays
-export const isPlainObject = (obj: any): boolean => {
-  if (!obj || typeof obj !== 'object' || obj instanceof Array) return false
-  return true
+/** simplistic implementation to filter-out arrays */
+export function isPlainObject (obj: unknown): boolean {
+  return Boolean(obj) && typeof obj === 'object' && !Array.isArray(obj)
 }
 
 // encodeURIComponent ignores !, ', (, ), and *
@@ -27,13 +36,23 @@ export const fixedEncodeURIComponent = (str: string): string => {
 
 export const replaceSpaceByUnderscores = (str: string): string => str.replace(/\s/g, '_')
 
-export const uniq = (array: string[]): string[] => Array.from(new Set(array))
+export function uniq<T> (array: readonly T[]): T[] {
+  return Array.from(new Set(array))
+}
 
 const encodeCharacter = (char: string): string => '%' + char.charCodeAt(0).toString(16)
 
-export function rejectObsoleteInterface (args): void {
+export function rejectObsoleteInterface (args: IArguments): void {
   if (args.length !== 1 || !isPlainObject(args[0])) {
     throw new Error(`Since wikibase-sdk v9.0.0, this function expects arguments to be passed in an object
     See https://github.com/maxlath/wikibase-sdk/blob/main/CHANGELOG.md`)
   }
+}
+
+/**
+ * Checks if the `element` is of one of the entries of `all`
+ * @example const isWmLanguageCode: lang is WmLanguageCode = isOfType(languages, lang)
+ */
+export function isOfType<T extends string> (all: readonly T[], element: unknown): element is T {
+  return typeof element === 'string' && (all as readonly string[]).includes(element)
 }

--- a/src/wikibase-sdk.ts
+++ b/src/wikibase-sdk.ts
@@ -14,7 +14,7 @@ import { searchEntitiesFactory } from './queries/search_entities.js'
 import { sparqlQueryFactory } from './queries/sparql_query.js'
 import { buildUrlFactory } from './utils/build_url.js'
 import { isPlainObject } from './utils/utils.js'
-import type { InstanceConfig } from './types/options.js'
+import type { InstanceConfig, Url } from './types/options.js'
 import type { Wbk } from './types/wbk.js'
 
 const tip = `Tip: if you just want to access functions that don't need an instance or a sparqlEndpoint,
@@ -92,7 +92,7 @@ export function WBK (config: InstanceConfig): Wbk {
   }
 }
 
-const validateEndpoint = (name, url) => {
+const validateEndpoint = (name: string, url: Url) => {
   if (!(typeof url === 'string' && url.startsWith('http'))) {
     throw new Error(`invalid ${name}: ${url}`)
   }

--- a/tests/general.ts
+++ b/tests/general.ts
@@ -12,9 +12,8 @@ describe('builder', () => {
   it('should reference instance-independant helpers', () => {
     should(parse).be.an.Object()
     should(simplify).be.an.Object()
-    parse.entities.should.be.an.Function()
-    // @ts-ignore
-    simplify.labels.should.be.an.Function()
+    parse.entities.should.be.a.Function()
+    simplify.labels.should.be.a.Function()
     isEntityId.should.be.a.Function()
     getSitelinkData.should.be.a.Function()
   })
@@ -104,11 +103,11 @@ describe('index', () => {
     wbk.truthyClaims.should.be.a.Function()
     wbk.truthyPropertyClaims.should.be.a.Function()
 
-    wbk.parse.entities.should.be.an.Function()
+    wbk.parse.entities.should.be.a.Function()
 
     wbk.parse.should.be.an.Object()
-    wbk.parse.entities.should.be.an.Function()
-    wbk.parse.pagesTitles.should.be.an.Function()
+    wbk.parse.entities.should.be.a.Function()
+    wbk.parse.pagesTitles.should.be.a.Function()
 
     wbk.isEntityId.should.be.a.Function()
     wbk.isItemId.should.be.a.Function()

--- a/tests/get_entities.ts
+++ b/tests/get_entities.ts
@@ -8,7 +8,7 @@ const getEntities = getEntitiesFactory(buildUrl)
 describe('wikidata getEntities', () => {
   describe('polymorphism', () => {
     it('rejects parameters as multiple arguments', () => {
-      // @ts-ignore
+      // @ts-expect-error
       (() => getEntities('Q1', 'fr', 'info', 'json')).should.throw()
     })
 

--- a/tests/get_entities_from_sitelinks.ts
+++ b/tests/get_entities_from_sitelinks.ts
@@ -8,9 +8,9 @@ const getEntitiesFromSitelinks = getEntitiesFromSitelinksFactory(buildUrl)
 describe('getEntitiesFromSitelinks', () => {
   describe('polymorphism', () => {
     it('rejects parameters as multiple arguments', () => {
-      // @ts-ignore
+      // @ts-expect-error
       (() => getEntitiesFromSitelinks('Lyon')).should.throw()
-      // @ts-ignore
+      // @ts-expect-error
       ;(() => getEntitiesFromSitelinks('Lyon', 'en')).should.throw()
     })
   })
@@ -51,7 +51,7 @@ describe('getEntitiesFromSitelinks', () => {
     })
 
     it('converts 2-letters language codes to Wikipedia sites', () => {
-      // @ts-ignore
+      // @ts-expect-error
       const query = parseUrlQuery(getEntitiesFromSitelinks({ titles: 'Lyon', sites: [ 'it', 'fr' ] }))
       query.sites.should.equal('itwiki|frwiki')
     })

--- a/tests/get_entity_revision.ts
+++ b/tests/get_entity_revision.ts
@@ -7,12 +7,12 @@ const getEntityRevision = getEntityRevisionFactory(instance, wgScriptPath)
 
 describe('getEntityRevision', () => {
   it('should reject an invalid entity id', () => {
-    // @ts-ignore
+    // @ts-expect-error
     (() => getEntityRevision({ id: '3548931' })).should.throw('invalid entity id: 3548931')
   })
 
   it('should reject an invalid revision', () => {
-    // @ts-ignore
+    // @ts-expect-error
     (() => getEntityRevision({ id: 'Q123', revision: 'foo' })).should.throw('invalid revision id: foo')
   })
 

--- a/tests/get_many_entities.ts
+++ b/tests/get_many_entities.ts
@@ -22,7 +22,7 @@ describe('wikidata getManyEntities', () => {
 
   describe('polymorphism', () => {
     it('should reject parameters as multiple arguments', () => {
-      // @ts-ignore
+      // @ts-expect-error
       (() => getManyEntities(manyIds, 'fr', 'info', 'json')).should.throw()
     })
 
@@ -46,7 +46,7 @@ describe('wikidata getManyEntities', () => {
 
   describe('ids', () => {
     it('should throw if passed an id string', () => {
-      // @ts-ignore
+      // @ts-expect-error
       (() => getManyEntities({ ids: 'Q535' })).should.throw()
     })
   })

--- a/tests/get_many_entities.ts
+++ b/tests/get_many_entities.ts
@@ -3,9 +3,10 @@ import should from 'should'
 import { getManyEntitiesFactory } from '../src/queries/get_many_entities.js'
 import { buildUrl } from './lib/tests_env.js'
 import { parseUrlQuery } from './lib/utils.js'
+import type { ItemId } from '../src/types/entity.js'
 
 const getManyEntities = getManyEntitiesFactory(buildUrl)
-const manyIds = range(1, 80).map(id => `Q${id}`)
+const manyIds = range(1, 80).map(id => `Q${id}` as ItemId)
 
 describe('wikidata getManyEntities', () => {
   describe('general', () => {

--- a/tests/get_reverse_claims.ts
+++ b/tests/get_reverse_claims.ts
@@ -10,7 +10,7 @@ describe('getReverseClaims', () => {
   })
 
   it('should reject invalid property ids', () => {
-    // @ts-ignore
+    // @ts-expect-error
     (() => getReverseClaims({ properties: 'foo', values: 'Q535' })).should.throw('invalid property id: foo')
   })
 

--- a/tests/get_revisions.ts
+++ b/tests/get_revisions.ts
@@ -9,7 +9,7 @@ const getRevisions = getRevisionsFactory(buildUrl)
 
 describe('getRevisions', () => {
   it('should reject invalid ids', () => {
-    // @ts-ignore
+    // @ts-expect-error
     (() => getRevisions({ ids: 'foo' })).should.throw('invalid entity page title: foo')
   })
 
@@ -17,6 +17,7 @@ describe('getRevisions', () => {
     (() => getRevisions({ ids: 'Item:Q123' })).should.not.throw()
     ;(() => getRevisions({ ids: 'Property:P123' })).should.not.throw()
     ;(() => getRevisions({ ids: 'Lexeme:L123' })).should.not.throw()
+    // @ts-expect-error title is invalid
     ;(() => getRevisions({ ids: 'Property:Q123' })).should.throw('invalid entity page title: Property:Q123')
   })
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,24 +1,25 @@
 import 'should'
 
 import {
+  getEntityIdFromGuid,
+  getImageUrl,
+  getNumericId,
+  isEntityId,
+  isEntityPageTitle,
+  isEntitySchemaId,
+  isFormId,
+  isGuid,
+  isHash,
+  isItemId,
+  isLexemeId,
+  isMediaInfoId,
+  isNumericId,
+  isPropertyClaimsId,
+  isPropertyId,
+  isSenseId,
   wikibaseTimeToEpochTime,
   wikibaseTimeToISOString,
   wikibaseTimeToSimpleDay,
-  isEntityId,
-  isItemId,
-  isPropertyId,
-  isLexemeId,
-  isFormId,
-  isSenseId,
-  isGuid,
-  isHash,
-  isPropertyClaimsId,
-  isEntitySchemaId,
-  isEntityPageTitle,
-  isNumericId,
-  getNumericId,
-  getImageUrl,
-  getEntityIdFromGuid,
 } from '../src/helpers/helpers.js'
 import { requireJson } from './lib/utils.js'
 
@@ -169,6 +170,7 @@ describe('helpers', () => {
       isEntityId('L525-F1').should.be.true()
       isEntityId('L525-S1').should.be.true()
       isEntityId('L525-Z1').should.be.false()
+      isEntityId('M42').should.be.true()
       isEntityId('31').should.be.false()
       // @ts-expect-error non string input
       isEntityId(31).should.be.false()
@@ -233,6 +235,14 @@ describe('helpers', () => {
       isSenseId('L525').should.be.false()
       isSenseId('L525S1').should.be.false()
       isSenseId('L525-F1').should.be.false()
+    })
+  })
+
+  describe('isMediaInfoId', () => {
+    it('should accept media info ids', () => {
+      isMediaInfoId('M42').should.be.true()
+      isMediaInfoId('Q42').should.be.false()
+      isMediaInfoId('42').should.be.false()
     })
   })
 
@@ -303,6 +313,7 @@ describe('helpers', () => {
       getNumericId('Q1').should.equal('1')
       getNumericId('P1').should.equal('1')
       getNumericId('L1').should.equal('1')
+      getNumericId('M1').should.equal('1')
       getNumericId.bind(null, 'L1-F1').should.throw()
       getNumericId.bind(null, 'L1-S1').should.throw()
     })

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -14,6 +14,7 @@ import {
   isHash,
   isPropertyClaimsId,
   isEntitySchemaId,
+  isEntityPageTitle,
   isNumericId,
   getNumericId,
   getImageUrl,
@@ -169,7 +170,6 @@ describe('helpers', () => {
       isEntityId('L525-S1').should.be.true()
       isEntityId('L525-Z1').should.be.false()
       isEntityId('31').should.be.false()
-      // @ts-ignore
       isEntityId(31).should.be.false()
       isEntityId('Z31').should.be.false()
       isEntityId('q31').should.be.false()
@@ -182,7 +182,6 @@ describe('helpers', () => {
       isItemId('Q571').should.be.true()
       isItemId('P31').should.be.false()
       isItemId('31').should.be.false()
-      // @ts-ignore
       isItemId(31).should.be.false()
       isItemId('Z31').should.be.false()
       isItemId('q31').should.be.false()
@@ -195,7 +194,6 @@ describe('helpers', () => {
       isPropertyId('P31').should.be.true()
       isPropertyId('Q571').should.be.false()
       isPropertyId('31').should.be.false()
-      // @ts-ignore
       isPropertyId(31).should.be.false()
       isPropertyId('Z31').should.be.false()
       isPropertyId('q31').should.be.false()
@@ -209,7 +207,6 @@ describe('helpers', () => {
       isLexemeId('P31').should.be.false()
       isLexemeId('Q571').should.be.false()
       isLexemeId('31').should.be.false()
-      // @ts-ignore
       isLexemeId(31).should.be.false()
       isLexemeId('Z31').should.be.false()
       isLexemeId('q31').should.be.false()
@@ -273,6 +270,20 @@ describe('helpers', () => {
     it('should accept entity schema ids', () => {
       isEntitySchemaId('E123').should.be.true()
       isEntitySchemaId('Q123').should.be.false()
+    })
+  })
+
+  describe('isEntityPageTitle', () => {
+    it('should accept correct titles', () => {
+      isEntityPageTitle('Item:Q42').should.be.true()
+      isEntityPageTitle('Lexeme:L42').should.be.true()
+      isEntityPageTitle('Property:P42').should.be.true()
+      isEntityPageTitle('Q42').should.be.true()
+
+      isEntityPageTitle('Item:L42').should.be.false()
+      isEntityPageTitle('Lexeme:P42').should.be.false()
+      isEntityPageTitle('Property:Q42').should.be.false()
+      isEntityPageTitle('P42').should.be.false()
     })
   })
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -170,6 +170,7 @@ describe('helpers', () => {
       isEntityId('L525-S1').should.be.true()
       isEntityId('L525-Z1').should.be.false()
       isEntityId('31').should.be.false()
+      // @ts-expect-error non string input
       isEntityId(31).should.be.false()
       isEntityId('Z31').should.be.false()
       isEntityId('q31').should.be.false()
@@ -182,6 +183,7 @@ describe('helpers', () => {
       isItemId('Q571').should.be.true()
       isItemId('P31').should.be.false()
       isItemId('31').should.be.false()
+      // @ts-expect-error non string input
       isItemId(31).should.be.false()
       isItemId('Z31').should.be.false()
       isItemId('q31').should.be.false()
@@ -194,6 +196,7 @@ describe('helpers', () => {
       isPropertyId('P31').should.be.true()
       isPropertyId('Q571').should.be.false()
       isPropertyId('31').should.be.false()
+      // @ts-expect-error non string input
       isPropertyId(31).should.be.false()
       isPropertyId('Z31').should.be.false()
       isPropertyId('q31').should.be.false()
@@ -207,6 +210,7 @@ describe('helpers', () => {
       isLexemeId('P31').should.be.false()
       isLexemeId('Q571').should.be.false()
       isLexemeId('31').should.be.false()
+      // @ts-expect-error non string input
       isLexemeId(31).should.be.false()
       isLexemeId('Z31').should.be.false()
       isLexemeId('q31').should.be.false()

--- a/tests/lib/utils.ts
+++ b/tests/lib/utils.ts
@@ -1,16 +1,21 @@
 import { createRequire } from 'module'
+import type { Url } from '../../src/types/options.js'
 
 // Importing JSON is still experimental in Node v18 https://nodejs.org/api/esm.html#import-assertions
 // so ESlint doesn't support it and complains with "Parsing error: Unexpected token assert"
 // thus this work around to require json files the old CommonJS way
 // See https://www.stefanjudis.com/snippets/how-to-import-json-files-in-es-modules-node-js/
-export const requireJson = (requiringUrl, jsonFilePath) => createRequire(requiringUrl)(jsonFilePath)
+export const requireJson = (requiringUrl: string | URL, jsonFilePath: string) => createRequire(requiringUrl)(jsonFilePath)
 
-export const objLenght = obj => Object.keys(obj).length
+export function objLenght<K extends string | number | symbol> (obj: Partial<Readonly<Record<K, unknown>>>) {
+  return Object.keys(obj).length
+}
 
-export const parseQuery = query => Object.fromEntries(new URLSearchParams(query))
+export function parseQuery (query: string | string[][] | Record<string, string> | URLSearchParams) {
+  return Object.fromEntries(new URLSearchParams(query))
+}
 
-export const parseUrlQuery = url => {
+export function parseUrlQuery (url: Url) {
   const { searchParams } = new URL(url)
   return searchParams ? Object.fromEntries(searchParams) : {}
 }

--- a/tests/parse.ts
+++ b/tests/parse.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import 'should'
 import { parse } from '../src/helpers/parse_responses.js'
 import { requireJson } from './lib/utils.js'
@@ -17,8 +16,11 @@ describe('parse', () => {
         const entities = parse.entities(wbgetentitiesResponse)
         entities.should.be.an.Object()
         entities.Q3235026.should.be.an.Object()
+        // @ts-expect-error
         entities.Q3235026.labels.should.be.an.Object()
+        // @ts-expect-error
         entities.Q3235026.descriptions.should.be.an.Object()
+        // @ts-expect-error
         entities.Q3235026.claims.should.be.an.Object()
       })
     })

--- a/tests/rank.ts
+++ b/tests/rank.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import 'should'
 import { cloneDeep } from 'lodash-es'
 import { truthyClaims, truthyPropertyClaims } from '../src/helpers/rank.js'
@@ -11,9 +10,8 @@ describe('truthyClaims', () => {
     const Q4115189Claims = cloneDeep(Q4115189.claims)
     Q4115189Claims.P135.length.should.equal(3)
     const truthyOnly = truthyClaims(Q4115189Claims)
-    // @ts-ignore
     truthyOnly.P135.length.should.equal(1)
-    // @ts-ignore
+    // @ts-expect-error
     truthyOnly.P135[0].mainsnak.datavalue.value.id.should.equal('Q2044250')
   })
 })
@@ -24,6 +22,7 @@ describe('truthyPropertyClaims', () => {
     Q4115189Claims.P135.length.should.equal(3)
     const truthyOnly = truthyPropertyClaims(Q4115189Claims.P135)
     truthyOnly.length.should.equal(1)
+    // @ts-expect-error
     truthyOnly[0].mainsnak.datavalue.value.id.should.equal('Q2044250')
   })
 })

--- a/tests/search_entities.ts
+++ b/tests/search_entities.ts
@@ -92,7 +92,7 @@ describe('searchEntities', () => {
     })
 
     it('should reject an invalid type parameter', () => {
-      // @ts-ignore
+      // @ts-expect-error
       (() => searchEntities({ search: 'alphabet', type: 'foo' })).should.throw()
     })
   })

--- a/tests/simplify_claims.ts
+++ b/tests/simplify_claims.ts
@@ -4,6 +4,7 @@ import should from 'should'
 import { simplifyClaim, simplifyPropertyClaims, simplifyClaims } from '../src/helpers/simplify_claims.js'
 import { uniq } from '../src/utils/utils.js'
 import { requireJson } from './lib/utils.js'
+import type { SimplifySnakOptions } from '../src/types/simplify_claims.js'
 
 const L525 = requireJson(import.meta.url, './data/L525.json')
 const Q1 = requireJson(import.meta.url, './data/Q1.json')
@@ -151,6 +152,7 @@ describe('simplifyPropertyClaims', () => {
   })
 
   it('should tolerate empty inputs', () => {
+    // @ts-expect-error empty input is not typed
     const simplified = simplifyPropertyClaims()
     simplified.should.be.an.Array()
     simplified.length.should.equal(0)
@@ -487,8 +489,8 @@ describe('simplifyClaim', () => {
   describe('time converter', () => {
     it('should use a custom time converter when one is set', () => {
       const claim = Q646148.claims.P569[0]
-      const simplifyTimeClaim = timeConverter => simplifyClaim(claim, { timeConverter })
-      simplifyTimeClaim().should.equal('1939-11-08T00:00:00.000Z')
+      const simplifyTimeClaim = (timeConverter: SimplifySnakOptions['timeConverter']) => simplifyClaim(claim, { timeConverter })
+      simplifyTimeClaim(undefined).should.equal('1939-11-08T00:00:00.000Z')
       simplifyTimeClaim('iso').should.equal('1939-11-08T00:00:00.000Z')
       simplifyTimeClaim('epoch').should.equal(-951436800000)
       simplifyTimeClaim('simple-day').should.equal('1939-11-08')
@@ -499,8 +501,8 @@ describe('simplifyClaim', () => {
 
     it('should be able to parse long dates', () => {
       const claim = Q1.claims.P580[0]
-      const simplifyTimeClaim = timeConverter => simplifyClaim(claim, { timeConverter })
-      simplifyTimeClaim().should.equal('-13798000000-01-01T00:00:00Z')
+      const simplifyTimeClaim = (timeConverter: SimplifySnakOptions['timeConverter']) => simplifyClaim(claim, { timeConverter })
+      simplifyTimeClaim(undefined).should.equal('-13798000000-01-01T00:00:00Z')
       simplifyTimeClaim('none').should.equal('-13798000000-00-00T00:00:00Z')
       simplifyTimeClaim('iso').should.equal('-13798000000-01-01T00:00:00Z')
       simplifyTimeClaim('simple-day').should.equal('-13798000000')

--- a/tests/simplify_entity.ts
+++ b/tests/simplify_entity.ts
@@ -16,6 +16,7 @@ describe('simplify.entity', () => {
   it('should support items', () => {
     const Q571Clone = cloneDeep(Q571)
     const simplifiedEntity = simplifyEntity(Q571Clone)
+    if (simplifiedEntity.type !== 'item') throw new TypeError()
     simplifiedEntity.type.should.equal('item')
     simplifiedEntity.labels.fr.should.equal('livre')
     simplifiedEntity.descriptions.fr.should.equal('document écrit formé de pages reliées entre elles')
@@ -29,6 +30,7 @@ describe('simplify.entity', () => {
   it('should support properties', () => {
     const P8098Clone = cloneDeep(P8098)
     const simplifiedEntity = simplifyEntity(P8098Clone)
+    if (simplifiedEntity.type !== 'property') throw new TypeError()
     simplifiedEntity.type.should.equal('property')
     simplifiedEntity.datatype.should.equal('external-id')
     simplifiedEntity.labels.fr.should.equal('identifiant Biographical Dictionary of Architects in Canada')
@@ -43,10 +45,10 @@ describe('simplify.entity', () => {
   it('should support lexemes', () => {
     const L525Clone = cloneDeep(L525)
     const simplifiedEntity = simplifyEntity(L525Clone)
+    if (simplifiedEntity.type !== 'lexeme') throw new TypeError()
     simplifiedEntity.type.should.equal('lexeme')
     simplifiedEntity.lemmas.should.be.an.Object()
     simplifiedEntity.lemmas.fr.should.equal('maison')
-    simplifiedEntity.claims.should.be.an.Object()
     simplifiedEntity.lexicalCategory.should.equal('Q1084')
     simplifiedEntity.language.should.equal('Q150')
     simplifiedEntity.claims.should.be.an.Object()

--- a/tests/simplify_qualifiers.ts
+++ b/tests/simplify_qualifiers.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import should from 'should'
 import { simplifyQualifier, simplifyPropertyQualifiers, simplifyQualifiers } from '../src/helpers/simplify_claims.js'
 import { requireJson } from './lib/utils.js'

--- a/tests/simplify_references.ts
+++ b/tests/simplify_references.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import 'should'
 import { simplifyReferences } from '../src/helpers/simplify_claims.js'
 import { requireJson } from './lib/utils.js'
@@ -7,6 +6,7 @@ const Q217447 = requireJson(import.meta.url, './data/Q217447.json')
 
 describe('simplifyReferences', () => {
   it('should simplify references', () => {
+    // @ts-expect-error
     simplifyReferences(Q217447.claims.P131[0].references)
     .should.deepEqual([ { P248: [ 'Q3485482' ] } ])
   })

--- a/tests/simplify_sitelinks.ts
+++ b/tests/simplify_sitelinks.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import should from 'should'
-import simplifySitelinks from '../src/helpers/simplify_sitelinks.js'
+import { simplifySitelinks } from '../src/helpers/simplify_sitelinks.js'
 import { requireJson, objLenght } from './lib/utils.js'
 
 const Q571 = requireJson(import.meta.url, './data/Q571.json')
@@ -39,6 +39,7 @@ describe('simplify.sitelinks', () => {
 
   it('should not throw when a sitelink is null ', () => {
     const sitelinks = { frwiki: null }
+    // @ts-expect-error
     simplifySitelinks(sitelinks).should.deepEqual(sitelinks)
   })
 })

--- a/tests/sitelinks_helpers.ts
+++ b/tests/sitelinks_helpers.ts
@@ -1,10 +1,9 @@
-// @ts-nocheck
 import 'should'
 import { getSitelinkUrl, getSitelinkData, isSitelinkKey } from '../src/helpers/sitelinks.js'
 
 describe('getSitelinkUrl', () => {
   it('should be a function', () => {
-    getSitelinkUrl.should.be.an.Function()
+    getSitelinkUrl.should.be.a.Function()
   })
 
   it('should return a sitelink URL', () => {
@@ -99,7 +98,9 @@ describe('getSitelinkUrl', () => {
   })
 
   it('should reject invalid sitelinks', () => {
+    // @ts-expect-error
     (() => getSitelinkUrl({ site: 'frperlinpinpin', title: 'Lyon' })).should.throw()
+    // @ts-expect-error
     ;(() => getSitelinkUrl({ site: 'frwikiwiki', title: 'Lyon' })).should.throw()
   })
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -23,8 +23,7 @@ describe('utils', () => {
     })
 
     it('should return false for undefined', () => {
-      // @ts-ignore
-      isPlainObject().should.equal(false)
+      isPlainObject(undefined).should.equal(false)
     })
   })
 })


### PR DESCRIPTION
I refactored mainly helpers and utils as they are the core of the library and used on different places a lot. Getting them right seemed to be a good start. Also adapted some other things when coming by them.

I switched the `@ts-ignore` to `@ts-expect-error` which error when there is no error. That way its easier to search for things that still need better typings. I also tried to get rid of the `@ts-nocheck` as these hide a bunch of bad typings. Sadly especially the simplify magic has a lot of typing issues so I couldnt remove all of them.

Strange finding: the regex of isEntityId allows for some `M42` string but I don't even know what hat is on Wikibase and its not in the types. So either its wrong or the types are missing it.

Having all these tests was great when doing refactoring and checking that everything still works. Thats awesome @maxlath!