### PR TITLE
refactor: improve Wdk export

### DIFF
--- a/src/helpers/parse_responses.ts
+++ b/src/helpers/parse_responses.ts
@@ -18,17 +18,15 @@ export interface CirrusSearchPagesResponse {
   }
 }
 
-function entities (res: WbGetEntitiesResponse): SimplifiedEntities {
+export function entities (res: WbGetEntitiesResponse): SimplifiedEntities {
   // @ts-expect-error Legacy convenience for the time the 'request' lib was all the rage
   res = res.body || res
   const { entities } = res
   return simplifyEntities(entities)
 }
 
-function pagesTitles (res: CirrusSearchPagesResponse): Titles {
+export function pagesTitles (res: CirrusSearchPagesResponse): Titles {
   // @ts-expect-error Same behavior as above
   res = res.body || res
   return res.query.search.map(result => result.title)
 }
-
-export const parse = { entities, pagesTitles } as const

--- a/src/helpers/simplify.ts
+++ b/src/helpers/simplify.ts
@@ -1,62 +1,38 @@
-
-import {
+export {
   simplifyClaim as claim,
-  simplifyPropertyClaims as propertyClaims,
   simplifyClaims as claims,
-  simplifyQualifier as qualifier,
+  simplifyPropertyClaims as propertyClaims,
   simplifyPropertyQualifiers as propertyQualifiers,
+  simplifyQualifier as qualifier,
   simplifyQualifiers as qualifiers,
   simplifyReferences as references,
 } from './simplify_claims.js'
-import {
+export {
   simplifyForm as form,
   simplifyForms as forms,
 } from './simplify_forms.js'
-import {
+export {
   simplifySense as sense,
   simplifySenses as senses,
 } from './simplify_senses.js'
-import { simplifySitelinks as sitelinks } from './simplify_sitelinks.js'
-import { simplifySparqlResults as sparqlResults } from './simplify_sparql_results.js'
-import {
-  simplifyLabels as labels,
-  simplifyDescriptions as descriptions,
+export { simplifySitelinks as sitelinks } from './simplify_sitelinks.js'
+export { simplifySparqlResults as sparqlResults } from './simplify_sparql_results.js'
+export {
   simplifyAliases as aliases,
+  simplifyDescriptions as descriptions,
+  simplifyGlosses as glosses,
+  simplifyLabels as labels,
   simplifyLemmas as lemmas,
   simplifyRepresentations as representations,
-  simplifyGlosses as glosses,
 } from './simplify_text_attributes.js'
+export {
+  simplifyEntities as entities,
+  simplifyEntity as entity,
+} from './simplify_entity.js'
 
-export const simplify = {
-  labels,
-  descriptions,
-  aliases,
-  claim,
-  propertyClaims,
-  claims,
-  qualifier,
-  propertyQualifiers,
-  qualifiers,
-  references,
-  sitelinks,
-
-  // Aliases
-  snak: claim,
-  propertySnaks: propertyClaims,
-  snaks: claims,
-
-  // Lexemes
-  lemmas,
-  representations,
-  glosses,
-  form,
-  forms,
-  sense,
-  senses,
-
-  sparqlResults,
-
-  // Set in ./simplify_entity
-  // entity,
-  // entities,
-}
+// Aliases
+export {
+  simplifyClaim as snak,
+  simplifyClaims as snaks,
+  simplifyPropertyClaims as propertySnaks,
+} from './simplify_claims.js'

--- a/src/helpers/simplify_entity.ts
+++ b/src/helpers/simplify_entity.ts
@@ -1,4 +1,4 @@
-import { simplify } from './simplify.js'
+import * as simplify from './simplify.js'
 import type { Entities, Entity, SimplifiedEntity } from '../types/entity.js'
 import type { SimplifyEntityOptions } from '../types/options.js'
 
@@ -44,16 +44,15 @@ export const simplifyEntities = (entities: Entities, options: SimplifyEntityOpti
   // @ts-expect-error
   if (entities.entities) entities = entities.entities
   const { entityPrefix } = options
-  return Object.keys(entities).reduce<any>((obj, key) => {
-    const entity = entities[key]
-    if (entityPrefix) key = `${entityPrefix}:${key}`
-    obj[key] = simplifyEntity(entity, options)
-    return obj
-  }, {})
-}
 
-// Set those here instead of in ./simplify to avoid a circular dependency
-// @ts-expect-error
-simplify.entity = simplifyEntity
-// @ts-expect-error
-simplify.entities = simplifyEntities
+  // TODO: key as string is only a best effort.
+  // key is either EntityID or `${prefix}:${EntityId}` based on options.entityPrefix
+  const result: Record<string, SimplifiedEntity> = {}
+
+  for (const [ key, entity ] of Object.entries(entities)) {
+    const resultKey = entityPrefix ? `${entityPrefix}:${key}` : key
+    result[resultKey] = simplifyEntity(entity, options)
+  }
+
+  return result
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
-import { WBK as _WBK } from './wikibase-sdk.js'
+import { WBK } from './wikibase-sdk.js'
 
-export default _WBK
-export const WBK = _WBK
+export default WBK
+
+export * from './wikibase-sdk.js'
 export * from './helpers/helpers.js'
 export * from './helpers/rank.js'
 export * from './helpers/sitelinks.js'
-export { parse } from './helpers/parse_responses.js'
-export { simplify } from './helpers/simplify.js'
+export * as parse from './helpers/parse_responses.js'
+export * as simplify from './helpers/simplify.js'
 export * from './helpers/simplify_claims.js'
 export * from './helpers/simplify_entity.js'
 export * from './helpers/simplify_forms.js'

--- a/src/wellknown/wikidata.org.ts
+++ b/src/wellknown/wikidata.org.ts
@@ -1,4 +1,4 @@
-import WBK from '../wikibase-sdk.js'
+import { WBK } from '../wikibase-sdk.js'
 
 export const wdk = WBK({
   instance: 'https://www.wikidata.org',

--- a/tests/general.ts
+++ b/tests/general.ts
@@ -80,7 +80,6 @@ describe('index', () => {
     wbk.getRevisions.should.be.a.Function()
     wbk.getEntitiesFromSitelinks.should.be.a.Function()
 
-    wbk.simplify.should.be.a.Object()
     wbk.simplify.entity.should.be.a.Function()
     wbk.simplify.entities.should.be.a.Function()
     wbk.simplify.labels.should.be.a.Function()
@@ -106,7 +105,6 @@ describe('index', () => {
 
     wbk.parse.entities.should.be.a.Function()
 
-    wbk.parse.should.be.an.Object()
     wbk.parse.entities.should.be.a.Function()
     wbk.parse.pagesTitles.should.be.a.Function()
 

--- a/tests/parse.ts
+++ b/tests/parse.ts
@@ -1,5 +1,5 @@
 import 'should'
-import { parse } from '../src/helpers/parse_responses.js'
+import * as parse from '../src/helpers/parse_responses.js'
 import { readJsonFile } from './lib/utils.js'
 
 const cirrusSearchPagesResponse = readJsonFile('./tests/data/cirrus_search_response.json')


### PR DESCRIPTION
the Wbk interface has a lot of duplicate types which result in easy errors.
This removes a lot of these duplicates and the exact types of the functions are used.
Minor downside: types like `type Url = string` get simplified sometimes by TypeScript and look like string afterwards.

This should not breaking as long as no one used simplify or parse as an object (why should someone do that) (look at the tests/general to see what I mean).

very likely conflicts with #100 but this can easily be extended as #100 would only be the change in index.ts with this Pull Request.