### PR TITLE
docs(readme): improve shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ This project received a [Wikimedia Project Grant](https://meta.wikimedia.org/wik
   <a href="https://wikidata.org"><img src="https://raw.githubusercontent.com/maxlath/wikibase-sdk/main/assets/wikidata.jpg" alt="wikidata"></a>
 </div>
 
-[![NPM](https://nodei.co/npm/wikibase-sdk.png?stars&downloads&downloadRank)](https://npmjs.com/package/wikibase-sdk/)
-
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Node](https://img.shields.io/badge/node-%3E=%20v6.4.0-brightgreen.svg)](http://nodejs.org)
-[![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
-
-[download stats](https://npm-stat.com/charts.html?package=wikibase-sdk)
+[![License](https://img.shields.io/npm/l/wikibase-sdk)](https://opensource.org/licenses/MIT)
+[![npm version](https://img.shields.io/npm/v/wikibase-sdk)](https://www.npmjs.com/package/wikibase-sdk)
+[![Required Node.js version](https://img.shields.io/node/v/wikibase-sdk)](http://nodejs.org)
+[![npm downloads](https://img.shields.io/npm/dw/wikibase-sdk)](https://npm-stat.com/charts.html?package=wikibase-sdk)
+[![code style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
+[![type definitions](https://img.shields.io/npm/types/wikibase-sdk)](https://www.typescriptlang.org/)
 
 ## Summary
 


### PR DESCRIPTION
Use shields which automatically load info from NPM like version, required Node.js version, license, … instead of custom tests.

Also add one for the type definitions and added a shield for the download stats link.

I removed the larger upper one as it doesnt show anything else then `npm install wikibase-sdk` (despite the url parameters containing starts and so on) as other shields already contain info like download stats.