### PR TITLE
refactor: use typescript lints over javascript lints

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -20,13 +20,8 @@ module.exports = {
   rules: {
     'array-bracket-spacing': [ 'error', 'always' ],
     'arrow-parens': [ 'error', 'as-needed' ],
-    'comma-dangle': [ 'error', {
-      arrays: 'always-multiline',
-      objects: 'always-multiline',
-      imports: 'always-multiline',
-      exports: 'always-multiline',
-      functions: 'never',
-    } ],
+    'comma-dangle': 'off',
+    '@typescript-eslint/comma-dangle': [ 'error', 'always-multiline' ],
     eqeqeq: [ 'error', 'smart' ],
     'implicit-arrow-linebreak': [ 'error', 'beside' ],
     'import/newline-after-import': 'error',
@@ -41,22 +36,27 @@ module.exports = {
         alphabetize: { order: 'asc' },
       },
     ],
-    indent: [ 'error', 2, { MemberExpression: 'off' } ],
+    'indent': 'off',
+    '@typescript-eslint/indent': [ 'error', 2, { MemberExpression: 'off' } ],
     'no-var': [ 'error' ],
     // Primarily to avoid false positive with interfaces declarations
     // See https://github.com/typescript-eslint/typescript-eslint/issues/1262
     'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
     'nonblock-statement-body-position': [ 'error', 'beside' ],
-    'object-curly-spacing': [ 'error', 'always' ],
+    'object-curly-spacing': 'off',
+    '@typescript-eslint/object-curly-spacing': [ 'error', 'always' ],
     'object-shorthand': [ 'error', 'properties' ],
     'prefer-arrow-callback': [ 'error' ],
     'prefer-const': [ 'error' ],
     'prefer-rest-params': 'off',
-    // See https://typescript-eslint.io/rules/semi/#how-to-use
-    semi: 'off',
-    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/ban-ts-comment': [ 'error', {
+      'ts-expect-error': false, // TODO: "allow-with-description",
+      'ts-nocheck': false,
+    } ],
     '@typescript-eslint/consistent-type-imports': [ 'error', { prefer: 'type-imports' } ],
     '@typescript-eslint/no-explicit-any': 'off',
+    semi: 'off',
     '@typescript-eslint/semi': [ 'error', 'never' ],
   },
   globals: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-n": "^15.6.1",
         "eslint-plugin-promise": "^6.1.1",
-        "eslint-plugin-standard": "^5.0.0",
         "lodash-es": "^4.17.21",
         "mocha": "^10.2.0",
         "should": "^13.2.3",
@@ -1447,30 +1446,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "deprecated": "standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -4986,13 +4961,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
       "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-promise": "^6.1.1",
-    "eslint-plugin-standard": "^5.0.0",
     "lodash-es": "^4.17.21",
     "mocha": "^10.2.0",
     "should": "^13.2.3",

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -18,7 +18,7 @@ import type {
 } from '../types/entity.js'
 import type { Url } from '../types/options.js'
 
-function isIdBuilder<T extends string> (regex: {readonly source: string, readonly flags: string}) {
+function isIdBuilder<T extends string> (regex: { readonly source: string, readonly flags: string }) {
   return (id: string): id is T => typeof id === 'string' && new RegExp(regex.source, regex.flags).test(id)
 }
 

--- a/src/helpers/simplify_text_attributes.ts
+++ b/src/helpers/simplify_text_attributes.ts
@@ -3,9 +3,7 @@ import type { Aliases, Descriptions, Glosses, Labels, Lemmas, Representations, S
 
 type InValue<T> = { readonly value: T }
 
-function singleValue<V> (
-  data: Partial<Readonly<Record<WmLanguageCode, InValue<V>>>>
-) {
+function singleValue<V> (data: Partial<Readonly<Record<WmLanguageCode, InValue<V>>>>) {
   const simplified: Partial<Record<WmLanguageCode, V>> = {}
   for (const [ lang, obj ] of Object.entries(data)) {
     simplified[lang] = obj != null ? obj.value : null
@@ -13,9 +11,7 @@ function singleValue<V> (
   return simplified
 }
 
-function multiValue<V> (
-  data: Partial<Readonly<Record<WmLanguageCode, ReadonlyArray<InValue<V>>>>>
-) {
+function multiValue<V> (data: Partial<Readonly<Record<WmLanguageCode, ReadonlyArray<InValue<V>>>>>) {
   const simplified: Partial<Record<WmLanguageCode, readonly V[]>> = {}
   for (const [ lang, obj ] of Object.entries(data)) {
     simplified[lang] = obj != null ? obj.map(o => o.value) : []

--- a/tests/simplify_qualifiers.ts
+++ b/tests/simplify_qualifiers.ts
@@ -103,8 +103,7 @@ describe('simplifyQualifiers', () => {
     it('should keep snaktype if requested', () => {
       const qualifier = Q19180293.claims.P1433[0].qualifiers.P1100[0]
       simplifyQualifier(qualifier, { keepSnaktypes: true })
-      .should.deepEqual({ value: undefined, snaktype: 'novalue' }
-      )
+      .should.deepEqual({ value: undefined, snaktype: 'novalue' })
     })
   })
 })


### PR DESCRIPTION
Some lints have an improved version for TypeScript. I disabled the JS ones and used the ones for TypeScript.

As the `eslint-config-standard` is used there is no need for the devDependency `eslint-plugin-standard`.