### PR TITLE
refactor: use typesave utils

### DIFF
--- a/src/helpers/rank.ts
+++ b/src/helpers/rank.ts
@@ -5,7 +5,7 @@ export function truthyPropertyClaims (propertyClaims: PropertyClaims): PropertyC
   const aggregate: Partial<Record<Rank, Claim[]>> = {}
   for (const claim of propertyClaims) {
     const { rank } = claim
-    aggregate[rank] ??= []
+    aggregate[rank] = aggregate[rank] || []
     aggregate[rank].push(claim)
   }
 

--- a/src/helpers/simplify_text_attributes.ts
+++ b/src/helpers/simplify_text_attributes.ts
@@ -1,3 +1,4 @@
+import { typedEntries } from '../utils/utils.js'
 import type { WmLanguageCode } from '../types/options.js'
 import type { Aliases, Descriptions, Glosses, Labels, Lemmas, Representations, SimplifiedAliases, SimplifiedDescriptions, SimplifiedGlosses, SimplifiedLabels, SimplifiedLemmas, SimplifiedRepresentations } from '../types/terms.js'
 
@@ -5,7 +6,7 @@ type InValue<T> = { readonly value: T }
 
 function singleValue<V> (data: Partial<Readonly<Record<WmLanguageCode, InValue<V>>>>) {
   const simplified: Partial<Record<WmLanguageCode, V>> = {}
-  for (const [ lang, obj ] of Object.entries(data)) {
+  for (const [ lang, obj ] of typedEntries(data)) {
     simplified[lang] = obj != null ? obj.value : null
   }
   return simplified
@@ -13,7 +14,7 @@ function singleValue<V> (data: Partial<Readonly<Record<WmLanguageCode, InValue<V
 
 function multiValue<V> (data: Partial<Readonly<Record<WmLanguageCode, ReadonlyArray<InValue<V>>>>>) {
   const simplified: Partial<Record<WmLanguageCode, readonly V[]>> = {}
-  for (const [ lang, obj ] of Object.entries(data)) {
+  for (const [ lang, obj ] of typedEntries(data)) {
     simplified[lang] = obj != null ? obj.map(o => o.value) : []
   }
   return simplified

--- a/src/queries/cirrus_search.ts
+++ b/src/queries/cirrus_search.ts
@@ -1,6 +1,6 @@
 // See https://www.wikidata.org/w/api.php?action=help&modules=query%2Bsearch
 
-import { rejectObsoleteInterface } from '../utils/utils.js'
+import { isAKey, rejectObsoleteInterface } from '../utils/utils.js'
 import type { Url, UrlResultFormat } from '../types/options.js'
 import type { BuildUrlFunction } from '../utils/build_url.js'
 
@@ -23,11 +23,12 @@ export function cirrusSearchPagesFactory (buildUrl: BuildUrlFunction) {
     rejectObsoleteInterface(arguments)
 
     // Accept sr parameters with or without prefix
-    for (const key in options) {
+    for (const [ key, value ] of Object.entries(options)) {
       if (key.startsWith('sr')) {
         const shortKey = key.replace(/^sr/, '')
+        if (!isAKey(options, shortKey)) throw new Error(`${key} is not a valid option`)
         if (options[shortKey] != null) throw new Error(`${shortKey} and ${key} are the same`)
-        options[shortKey] = options[key]
+        options[shortKey] = value
       }
     }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -56,3 +56,14 @@ export function rejectObsoleteInterface (args: IArguments): void {
 export function isOfType<T extends string> (all: readonly T[], element: unknown): element is T {
   return typeof element === 'string' && (all as readonly string[]).includes(element)
 }
+
+/** key is a key on the object */
+export function isAKey<T extends PropertyKey> (obj: Readonly<Partial<Record<T, unknown>>>, key: PropertyKey): key is T {
+  return Object.prototype.hasOwnProperty.call(obj, key)
+}
+
+/** like Object.entries() but with typed key */
+export function typedEntries<K extends string, V> (input: Readonly<Partial<Record<K, V>>>): Array<[K, V]> {
+  // @ts-expect-error string is not assignable to K as K is more specific
+  return Object.entries(input)
+}


### PR DESCRIPTION
Adds two type safe utils to work with JS builtins in a more type safe way.

Also prefer using `Object.entries` (or `typedEntries`) over `Object.keys(obj)` with manual access of the value `obj[key]` as indexed access could return undefined and TypeScript knows that (with noUncheckedIndexedAccess). Using entries there will contain the value so no need for another check.

(Part of #106)