### PR TITLE
Reduce allowed types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/lodash-es": "^4.17.6",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^18.11.18",
+        "@types/node": "^12.20.55",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
         "@typescript-eslint/parser": "^5.49.0",
         "@vercel/git-hooks": "^1.0.0",
@@ -302,9 +302,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -4045,9 +4045,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
     },
     "@types/semver": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/lodash-es": "^4.17.6",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "^12.20.55",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
     "@vercel/git-hooks": "^1.0.0",

--- a/tests/lib/utils.ts
+++ b/tests/lib/utils.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { readFileSync } from 'fs'
 import type { Url } from '../../src/types/options.js'
 
 export function readJsonFile (jsonFilePath: string) {
@@ -10,12 +10,22 @@ export function objLenght<K extends string | number | symbol> (obj: Partial<Read
 }
 
 export function parseQuery (query: string | string[][] | Record<string, string> | URLSearchParams) {
-  return Object.fromEntries(new URLSearchParams(query))
+  const searchParams = new URLSearchParams(query)
+  const result: Record<string, string> = {}
+  for (const [ key, value ] of searchParams) {
+    result[key] = value
+  }
+
+  return result
 }
 
 export function parseUrlQuery (url: Url) {
   const { searchParams } = new URL(url)
-  return searchParams ? Object.fromEntries(searchParams) : {}
+  const result: Record<string, string> = {}
+  for (const [ key, value ] of searchParams) {
+    result[key] = value
+  }
+  return result
 }
 
 export function assert (condition: boolean): asserts condition {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "target": "es2016",
-    "module": "esnext",
-    "moduleResolution": "nodenext",
+    "module": "es2015",
+    "moduleResolution": "node16",
     "declaration": true,
     "declarationMap": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
The `@types/node` package introduced some types which don't work in Node.js 12. Using the same version as the minimum required Node.js version changes this.

`Object.fromEntries` is ES2019 which is higher than the current target of ES2016. I used an implementation which works with ES2016.

According to [this config](https://github.com/tsconfig/bases/blob/main/bases/node12.json) Node.js 12 supports ES2019 so the alternative might be to raise the target. Browsers basically seem to [support it after 2019](https://caniuse.com/sr_es10).