### PR TITLE
fix(claim): improve SnakValue type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export * from './types/options.js'
 export * from './types/search.js'
 export * from './types/simplify_claims.js'
 export * from './types/sitelinks.js'
+export * from './types/snakvalue.js'
 export * from './types/sparql.js'
 export * from './types/terms.js'
 

--- a/src/types/claim.ts
+++ b/src/types/claim.ts
@@ -23,8 +23,6 @@ export type Claims = Record<PropertyId, PropertyClaims>
 export type Snaks = Record<PropertyId, PropertySnaks>
 
 export interface Snak {
-  // A mainsnak object won't have an id, as its already on the claim
-  id?: string
   datatype: DataType
   datavalue?: SnakValue
   hash: string
@@ -32,17 +30,13 @@ export interface Snak {
   snaktype: SnakType
 }
 
-export interface Qualifier extends Snak {
-  id: string
-}
+export type Qualifier = Snak
 
 export type PropertyQualifiers = Qualifier[]
 
 export type Qualifiers = Record<PropertyId, PropertyQualifiers>
 
-export interface ReferenceSnak extends Snak {
-  id: string
-}
+export type ReferenceSnak = Snak
 
 export interface Reference {
   hash: string

--- a/src/types/claim.ts
+++ b/src/types/claim.ts
@@ -1,4 +1,5 @@
 import type { PropertyId } from './entity.js'
+import type { SnakValue } from './snakvalue.js'
 import type { parsers } from '../helpers/parse_claim.js'
 
 export type Rank = 'normal' | 'preferred' | 'deprecated'
@@ -9,9 +10,9 @@ export interface Claim {
   id: string
   mainsnak: Snak
   rank: Rank
-  type: DataType
+  type: 'statement'
   qualifiers?: Qualifiers
-  'qualifiers-order'?: string[]
+  'qualifiers-order'?: PropertyId[]
   references?: Reference[]
 }
 
@@ -24,55 +25,12 @@ export type Snaks = Record<PropertyId, PropertySnaks>
 export interface Snak {
   // A mainsnak object won't have an id, as its already on the claim
   id?: string
-  datatype: string
+  datatype: DataType
   datavalue?: SnakValue
   hash: string
-  property: string
+  property: PropertyId
   snaktype: SnakType
 }
-
-export interface SnakValue {
-  type: DataType
-  value: unknown
-}
-
-export interface ClaimSnakTimeValue extends SnakValue {
-  type: 'time'
-  value: {
-    after: number
-    before: number
-    calendermodel: string
-    precision: number
-    time: string
-    timezone: number
-  }
-}
-
-export interface ClaimSnakQuantity extends SnakValue {
-  type: 'quantity'
-  value: {
-    amount: string
-    unit: string
-    upperBound?: string
-    lowerBound?: string
-  }
-}
-
-export interface ClaimSnakString extends SnakValue {
-  type: 'string'
-  value: string
-}
-
-export interface SnakEntityValue extends SnakValue {
-  type: 'wikibase-entityid'
-  value: {
-    id: string
-    'numeric-id': number
-    'entity-type': string
-  }
-}
-
-export type ClaimSnakWikibaseItem = SnakEntityValue
 
 export interface Qualifier extends Snak {
   id: string
@@ -89,7 +47,7 @@ export interface ReferenceSnak extends Snak {
 export interface Reference {
   hash: string
   snaks: Record<PropertyId, ReferenceSnak[]>
-  'snaks-order': string[]
+  'snaks-order': PropertyId[]
 }
 
 export type References = Reference[]

--- a/src/types/snakvalue.ts
+++ b/src/types/snakvalue.ts
@@ -1,0 +1,76 @@
+import type { EntityId, EntityType } from './entity.js'
+import type { WmLanguageCode } from './options.js'
+
+export type SnakValue =
+  | GlobecoordinateSnakValue
+  | MonolingualTextSnakValue
+  | QuantitySnakValue
+  | StringSnakValue
+  | TimeSnakValue
+  | WikibaseEntityIdSnakValue
+
+/** @deprecated use TimeSnakValue */
+export type ClaimSnakTimeValue = TimeSnakValue
+/** @deprecated use QuantitySnakValue */
+export type ClaimSnakQuantity = QuantitySnakValue
+/** @deprecated use StringSnakValue */
+export type ClaimSnakString = StringSnakValue
+/** @deprecated use WikibaseItemSnakValue */
+export type SnakEntityValue = WikibaseEntityIdSnakValue
+/** @deprecated use WikibaseItemSnakValue */
+export type ClaimSnakWikibaseItem = WikibaseEntityIdSnakValue
+
+export interface GlobecoordinateSnakValue {
+  type: 'globecoordinate';
+  value: {
+    latitude: number;
+    longitude: number;
+    altitude: number | null;
+    precision: number;
+    globe: string;
+  };
+}
+
+export interface MonolingualTextSnakValue {
+  type: 'monolingualtext';
+  value: {
+    language: WmLanguageCode;
+    text: string;
+  };
+}
+
+export interface QuantitySnakValue {
+  type: 'quantity';
+  value: {
+    amount: string;
+    unit: string;
+    upperBound?: string;
+    lowerBound?: string;
+  };
+}
+
+export interface StringSnakValue {
+  type: 'string';
+  value: string;
+}
+
+export interface TimeSnakValue {
+  type: 'time';
+  value: {
+    time: string;
+    timezone: number;
+    before: number;
+    after: number;
+    precision: number;
+    calendarmodel: string;
+  };
+}
+
+export interface WikibaseEntityIdSnakValue {
+  type: 'wikibase-entityid';
+  value: {
+    id: EntityId;
+    'numeric-id'?: number;
+    'entity-type': EntityType;
+  };
+}

--- a/tests/time.ts
+++ b/tests/time.ts
@@ -49,7 +49,6 @@ describe('time helpers', () => {
 
       Q970917.claims.P569.forEach((claim, i) => {
         assert(claim.mainsnak.datavalue.type === 'time')
-        // @ts-expect-error TODO: improve SnakValue to be a union
         should(wikibaseTimeToEpochTime(claim.mainsnak.datavalue.value)).equal(expected[i])
       })
     })
@@ -96,7 +95,6 @@ describe('time helpers', () => {
 
       Q970917.claims.P569.forEach((claim, i) => {
         assert(claim.mainsnak.datavalue.type === 'time')
-        // @ts-expect-error TODO: improve SnakValue to be a union
         should(wikibaseTimeToISOString(claim.mainsnak.datavalue.value)).equal(expected[i])
       })
     })
@@ -129,7 +127,6 @@ describe('time helpers', () => {
 
     it('should accept a value object', () => {
       assert(Q970917.claims.P569[0].mainsnak.datavalue.type === 'time')
-      // @ts-expect-error TODO: improve SnakValue to be a union
       should(wikibaseTimeToSimpleDay(Q970917.claims.P569[0].mainsnak.datavalue.value)).equal('1869-11')
     })
   })


### PR DESCRIPTION
also some minor Claim/Snak typing improvements.

SnakValue typings should be complete based on what I found [here](https://www.mediawiki.org/wiki/Wikibase/Indexing/RDF_Dump_Format#Value_representation).

Something I am not sure about: no `Snak` (`Qualifier` and `ReferenceSnak` included) contains an id (from the real world data I observed.
its optional for Snak but required for ReferenceSnak and Qualifier. I think this is wrong and can be remove on all 3 of them. But I might be missing something so can someone confirm me here? Its there so it probably has a reason?