### PR TITLE
Split simplifyClaim and simplifySnak

### DIFF
--- a/docs/simplify_claims.md
+++ b/docs/simplify_claims.md
@@ -1,7 +1,7 @@
 # Simplify claims
 *associated Wikibase doc: [DataModel](https://www.mediawiki.org/wiki/Wikibase/DataModel)*
 
-`simplify.claims` functions are part of the larger [`simplify.entity` functions family](simplify_entities_data.md)
+`simplifyClaims` functions are part of the larger [`simplifyEntity` functions family](simplify_entities_data.md)
 
 ## Summary
 
@@ -9,16 +9,16 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Intro](#intro)
-- [simplify.claims](#simplifyclaims)
-- [simplify.propertyClaims](#simplifypropertyclaims)
-- [simplify.claim](#simplifyclaim)
-- [simplify.qualifiers](#simplifyqualifiers)
-- [simplify.propertyQualifiers](#simplifypropertyqualifiers)
-- [simplify.qualifier](#simplifyqualifier)
-- [simplify.references](#simplifyreferences)
-- [simplify.snaks](#simplifysnaks)
-- [simplify.propertySnaks](#simplifypropertysnaks)
-- [simplify.snak](#simplifysnak)
+- [simplifyClaims](#simplifyclaims)
+- [simplifyPropertyClaims](#simplifypropertyclaims)
+- [simplifyClaim](#simplifyclaim)
+- [simplifyQualifiers](#simplifyqualifiers)
+- [simplifyPropertyQualifiers](#simplifypropertyqualifiers)
+- [simplifyQualifier](#simplifyqualifier)
+- [simplifyReferences](#simplifyreferences)
+- [simplifySnaks](#simplifysnaks)
+- [simplifyPropertySnaks](#simplifypropertysnaks)
+- [simplifySnak](#simplifysnak)
 - [Options](#options)
   - [Add prefixes to entities and properties ids](#add-prefixes-to-entities-and-properties-ids)
   - [Keep rich values](#keep-rich-values)
@@ -105,12 +105,13 @@ we could have
 "P279": [ "Q340169", "Q2342494", "Q386724" ]
 ```
 
-That's what `simplify.claims`, `simplify.propertyClaims`, `simplify.claim` do, each at their own level.
+That's what `simplifyClaims`, `simplifyPropertyClaims`, `simplifyClaim` do, each at their own level.
 
-## simplify.claims
-you just need to pass your entity' claims object to simplify.claims as such:
+## simplifyClaims
+you just need to pass your entity' claims object to `simplifyClaims` as such:
 ```js
-const simplifiedClaims = wbk.simplify.claims(entity.claims)
+import { simplifyClaims } from 'wikibase-sdk'
+const simplifiedClaims = simplifyClaims(entity.claims)
 ```
 
 in your workflow, that could give something like:
@@ -119,45 +120,74 @@ in your workflow, that could give something like:
 const url = wbk.getEntities('Q535')
 const { entities } = await fetch(url)
 const entity = entities.Q535
-const simplifiedClaims = wbk.simplify.claims(entity.claims)
+const simplifiedClaims = simplifyClaims(entity.claims)
 ```
 
 To keep things simple, "weird" values are removed (for instance, statements of datatype `wikibase-item` but set to `somevalues` instead of the expected Q id)
 
-Note that you don't need to instantiate a `wbk` object to access those `simplify` functions, as they can directly imported: `import { simplify } from 'wikibase-sdk'`
+Note that those functions are also available on the `wbk.simplify` object: `wbk.simplify.claims`, etc.
 
-## simplify.propertyClaims
-Same as simplify.claims but expects an array of claims, typically the array of claims of a specific property:
+## simplifyPropertyClaims
+Simplify an array of claims, typically the array of claims of a specific property:
 ```js
-const simplifiedP31Claims = wbk.simplify.propertyClaims(entity.claims.P31)
+import { simplifyPropertyClaims } from 'wikibase-sdk'
+const simplifiedP31Claims = simplifyPropertyClaims(entity.claims.P31, options)
 ```
 
-## simplify.claim
-Same as simplify.claims but expects a unique claim
+## simplifyClaim
+Simplify a unique claim
 ```js
-const simplifiedP31Claim = wbk.simplify.claim(entity.claims.P31[0])
+import { simplifyClaim } from 'wikibase-sdk'
+const simplifiedP31Claim = simplifyClaim(entity.claims.P31[0], options)
 ```
 
-## simplify.qualifiers
-Same interface as [simplify.claims](#simplifyclaims) but taking a qualifiers object
+## simplifyQualifiers
+Simplify a qualifiers object
+```js
+import { simplifyQualifiers } from 'wikibase-sdk'
+const claim = entity.claims.P31[0]
+const simplifiedQualifiers = simplifyQualifiers(claim.qualifiers, options)
+```
 
-## simplify.propertyQualifiers
-Same interface as [simplify.propertyClaims](#simplifypropertyclaims) but taking an array of qualifiers
+## simplifyPropertyQualifiers
+Simplify an array of qualifiers
+```js
+import { simplifyPropertyQualifiers } from 'wikibase-sdk'
+const claim = entity.claims.P31[0]
+const simplifiedP580Qualifiers = simplifyPropertyQualifiers(claim.qualifiers.P580, options)
+```
 
-## simplify.qualifier
-Same interface as [simplify.claim](#simplifyclaim) but taking a qualifier object
+## simplifyQualifier
+Simplify a qualifier
+```js
+import { simplifyQualifier } from 'wikibase-sdk'
+const claim = entity.claims.P31[0]
+const simplifiedQualifier = simplifyPropertyQualifiers(claim.qualifiers.P580[0], options)
+```
 
-## simplify.references
-Same interface as [simplify.claims](#simplifyclaims) but taking an array of reference records
+## simplifyReferences
+Simplify an array of references
+```js
+import { simplifyReferences } from 'wikibase-sdk'
+const claim = entity.claims.P31[0]
+const simplifiedReferences = simplifyReferences(claim.references, options)
+```
 
-## simplify.snaks
-Same interface as [simplify.claims](#simplifyclaims), but with a name that hints that it could also accept qualifiers or reference records.
+## simplifyReference
+Simplify a reference
+```js
+import { simplifyReference } from 'wikibase-sdk'
+const claim = entity.claims.P31[0]
+const simplifiedReference = simplifyReference(claim.references[0], options)
+```
 
-## simplify.propertySnaks
-Same interface as [simplify.propertyClaims](#simplifypropertyclaims), but with a name that hints that it could also accept an array of qualifiers snaks or an array of reference snaks.
-
-## simplify.snak
-Same interface as [simplify.claim](#simplifyclaim), but with a name that hints that it could also accept a qualifier or reference record [snak](https://www.wikidata.org/wiki/Wikidata:Glossary/en#Snak).
+## simplifySnak
+Simplify a [snak](https://www.wikidata.org/wiki/Wikidata:Glossary/en#Snak), be it a claim `mainsnak`, a qualifier snak, or a reference snak
+```js
+import { simplifySnak } from 'wikibase-sdk'
+const claim = entity.claims.P31[0]
+const simplifiedSnak = simplifySnak(claim.mainsnak, options)
+```
 
 ## Options
 
@@ -167,9 +197,9 @@ Same interface as [simplify.claim](#simplifyclaim), but with a name that hints t
 It may be useful to prefix entities and properties ids in case you work with data from several domains/sources. This can done by setting an entity prefix and/or a property prefix in the options:
 ```js
 const options = { entityPrefix: 'wd', propertyPrefix: 'wdt' }
-wbk.simplify.claims(entity.claims, options)
-wbk.simplify.propertyClaims(entity.claims.P31, options)
-wbk.simplify.claim(entity.claims.P31[0], options)
+simplifyClaims(entity.claims, options)
+simplifyPropertyClaims(entity.claims.P31, options)
+simplifyClaim(entity.claims.P31[0], options)
 ```
 Results would then look something like
 ```json
@@ -181,7 +211,7 @@ Results would then look something like
 ### Keep rich values
 > `keepRichValues`
 
-By default, `simplify.claims` returns only the simpliest values, so just a string for `monolingualtext` values and just a number for `quantity` values.
+By default, `simplifyClaims` returns only the simpliest values, so just a string for `monolingualtext` values and just a number for `quantity` values.
 By setting `keepRichValues=true`,
 - `monolingualtext` values will be objects on the pattern `{ text, language }`
 - `quantity` values will be objects on the pattern `{ amount, unit, upperBound, lowerBound }`
@@ -191,9 +221,9 @@ By setting `keepRichValues=true`,
 
 You can keep the value's types by passing `keepTypes: true` in the options:
 ```js
-wbk.simplify.claims(entity.claims, { keepTypes: true })
-wbk.simplify.propertyClaims(entity.claims.P50, { keepTypes: true })
-wbk.simplify.claim(entity.claims.P50[0], { keepTypes: true })
+simplifyClaims(entity.claims, { keepTypes: true })
+simplifyPropertyClaims(entity.claims.P50, { keepTypes: true })
+simplifyClaim(entity.claims.P50[0], { keepTypes: true })
 ```
 Results would then look something like
 ```json
@@ -233,9 +263,9 @@ If one if missing from this list (probably because it's new) you are welcome to 
 
 You can keep qualifiers by passing `keepQualifiers: true` in the options:
 ```js
-wbk.simplify.claims(entity.claims, { keepQualifiers: true })
-wbk.simplify.propertyClaims(entity.claims.P50, { keepQualifiers: true })
-wbk.simplify.claim(entity.claims.P50[0], { keepQualifiers: true })
+simplifyClaims(entity.claims, { keepQualifiers: true })
+simplifyPropertyClaims(entity.claims.P50, { keepQualifiers: true })
+simplifyClaim(entity.claims.P50[0], { keepQualifiers: true })
 ```
 Results would then look something like
 ```json
@@ -266,9 +296,9 @@ Results would then look something like
 
 You can keep reference by passing `keepReferences: true` in the options:
 ```js
-wbk.simplify.claims(entity.claims, { keepReferences: true })
-wbk.simplify.propertyClaims(entity.claims.P50, { keepReferences: true })
-wbk.simplify.claim(entity.claims.P50[0], { keepReferences: true })
+simplifyClaims(entity.claims, { keepReferences: true })
+simplifyPropertyClaims(entity.claims.P50, { keepReferences: true })
+simplifyClaim(entity.claims.P50[0], { keepReferences: true })
 ```
 Results would then look something like
 ```json
@@ -297,9 +327,9 @@ Results would then look something like
 You can keep claim ids (a.k.a. `guid`), references and qualifiers hashes by passing `keepIds: true` in the options:
 
 ```js
-wbk.simplify.claims(entity.claims, { keepIds: true })
-wbk.simplify.propertyClaims(entity.claims.P50, { keepIds: true })
-wbk.simplify.claim(entity.claims.P50[0], { keepIds: true })
+simplifyClaims(entity.claims, { keepIds: true })
+simplifyPropertyClaims(entity.claims.P50, { keepIds: true })
+simplifyClaim(entity.claims.P50[0], { keepIds: true })
 ```
 Results would then look something like
 ```json
@@ -318,9 +348,9 @@ Results would then look something like
 You can keep references and qualifiers hashes by passing `keepHashes: true` in the options:
 
 ```js
-wbk.simplify.claims(entity.claims, { keepHashes: true })
-wbk.simplify.propertyClaims(entity.claims.P50, { keepHashes: true })
-wbk.simplify.claim(entity.claims.P50[0], { keepHashes: true })
+simplifyClaims(entity.claims, { keepHashes: true })
+simplifyPropertyClaims(entity.claims.P50, { keepHashes: true })
+simplifyClaim(entity.claims.P50[0], { keepHashes: true })
 ```
 
 This option has no effect if neither `keepQualifiers` nor `keepReferences` is `true`.
@@ -351,26 +381,26 @@ Results would then look something like
 
 By default, [non-truthy statements](https://www.mediawiki.org/wiki/Wikibase/Indexing/RDF_Dump_Format#Truthy_statements) are filtered-out (keeping only claims of rank `preferred` if any, otherwise only claims of rank `normal`). This can be disable with this option.
 ```js
-wbk.simplify.claims(entity.claims, { keepNonTruthy: true })
-wbk.simplify.propertyClaims(entity.claims.P1082, { keepNonTruthy: true })
+simplifyClaims(entity.claims, { keepNonTruthy: true })
+simplifyPropertyClaims(entity.claims.P1082, { keepNonTruthy: true })
 ```
 
 #### Keep ranks
 > `keepRanks`
 ```js
-wbk.simplify.claims(entity.claims, { keepRanks: true })
-wbk.simplify.propertyClaims(entity.claims.P1082, { keepRanks: true })
-wbk.simplify.claim(entity.claims.P1082[0], { keepRanks: true })
+simplifyClaims(entity.claims, { keepRanks: true })
+simplifyPropertyClaims(entity.claims.P1082, { keepRanks: true })
+simplifyClaim(entity.claims.P1082[0], { keepRanks: true })
 ```
 This is mostly useful in combination with `keepNonTruthy`. Example: a city might have several population claims, with only the most recent having a `preferred` rank.
 
 ```js
 // By default, the simplification only keep the claim of rank 'preferred'
-wbk.simplify.propertyClaims(city.claims.P1082, { keepRanks: true })
+simplifyPropertyClaims(city.claims.P1082, { keepRanks: true })
 // => [ { value: 100000, rank: 'preferred' } ]
 
 // But the other claims can also be returned thank to 'keepNonTruthy'
-wbk.simplify.propertyClaims(city.claims.P1082, { keepRanks: true, keepNonTruthy: true })
+simplifyPropertyClaims(city.claims.P1082, { keepRanks: true, keepNonTruthy: true })
 // => [
 //       { value: 100000, rank: 'preferred' },
 //       { value: 90000, rank: 'normal' },
@@ -383,23 +413,23 @@ wbk.simplify.propertyClaims(city.claims.P1082, { keepRanks: true, keepNonTruthy:
 #### Customize novalue value
 > `novalueValue`
 ```js
-wbk.simplify.claims(claimWithNoValue, { novalueValue: '-' })
+simplifyClaims(claimWithNoValue, { novalueValue: '-' })
 // => '-'
 ```
 
 #### Customize somevalue value
 > `somevalueValue`
 ```js
-wbk.simplify.claims(claimWithSomeValue, { somevalueValue: '?' })
+simplifyClaims(claimWithSomeValue, { somevalueValue: '?' })
 // => '?'
 ```
 
 #### Keep snaktypes
 > `keepSnaktypes`
 ```js
-wbk.simplify.claims(claimWithSomeValue, { keepSnaktypes: true })
+simplifyClaims(claimWithSomeValue, { keepSnaktypes: true })
 // => { value: undefined, snaktype: 'somevalue' }
-wbk.simplify.claims(claimWithSomeValue, { keepSnaktypes: true, somevalueValue: '?' })
+simplifyClaims(claimWithSomeValue, { keepSnaktypes: true, somevalueValue: '?' })
 // => { value: '?', snaktype: 'somevalue' }
 ```
 
@@ -407,23 +437,23 @@ wbk.simplify.claims(claimWithSomeValue, { keepSnaktypes: true, somevalueValue: '
 > `keepAll`
 Activates all the `keep` options detailed above:
 ```js
-wbk.simplify.claims(claims, { keepAll: true })
+simplifyClaims(claims, { keepAll: true })
 // Is equivalent to
-wbk.simplify.claims(claims, { keepQualifiers: true, keepReferences: true, keepIds: true, keepHashes: true, keepTypes: true, keepSnaktypes: true, keepRanks: true })
+simplifyClaims(claims, { keepQualifiers: true, keepReferences: true, keepIds: true, keepHashes: true, keepTypes: true, keepSnaktypes: true, keepRanks: true })
 ```
 Those options can then be disabled one by one
 ```js
-wbk.simplify.claims(claims, { keepAll: true, keepTypes: false })
+simplifyClaims(claims, { keepAll: true, keepTypes: false })
 ```
 
 ### Change time parser
 
-By default, `simplify.claims` functions use [`wikidataTimeToISOString`](general_helpers.md#wikidataTimeToISOString) to parse [Wikidata time values](https://www.mediawiki.org/wiki/Wikibase/DataModel#Dates_and_times).
+By default, `simplifyClaims` functions use [`wikidataTimeToISOString`](general_helpers.md#wikidataTimeToISOString) to parse [Wikidata time values](https://www.mediawiki.org/wiki/Wikibase/DataModel#Dates_and_times).
 
 You can nevertheless request to use a different converter by setting the option `timeConverter`:
 
 ```js
-wbk.simplify.claims(claims, { timeConverter: 'iso' })
+simplifyClaims(claims, { timeConverter: 'iso' })
 ```
 
 Possible modes:
@@ -446,5 +476,5 @@ If none of those format fits your needs, you can pass a custom time converter fu
 ```
 ```js
 const timeConverterFn = ({ time, precision }) => `foo/${time}/${precision}/bar`
-wbk.simplify.claims(claims, { timeConverter })
+simplifyClaims(claims, { timeConverter })
 ```

--- a/scripts/compare_datatypes.ts
+++ b/scripts/compare_datatypes.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node
 import { kebabCase } from 'lodash-es'
 import { red, green } from 'tiny-chalk'
-import { parsers } from '../src/helpers/parse_claim.js'
+import { parsers } from '../src/helpers/parse_snak.js'
 import { readJsonFile } from '../tests/lib/utils.js'
 
 const supportedTypes = Object.keys(parsers)

--- a/src/helpers/parse_snak.ts
+++ b/src/helpers/parse_snak.ts
@@ -105,7 +105,7 @@ for (const [ datatype, parser ] of Object.entries(parsers)) {
   normalizedParsers[normalizeDatatype(datatype)] = parser
 }
 
-export function parseClaim (datatype, datavalue, options, claimId) {
+export function parseSnak (datatype, datavalue, options) {
   // Known case of missing datatype: form.claims, sense.claims, mediainfo.statements
   datatype = datatype || datavalue.type
 
@@ -118,7 +118,6 @@ export function parseClaim (datatype, datavalue, options, claimId) {
   } catch (err) {
     if (err.message === 'parsers[datatype] is not a function') {
       err.message = `${datatype} claim parser isn't implemented
-      Claim id: ${claimId}
       Please report to https://github.com/maxlath/wikibase-sdk/issues`
     }
     throw err

--- a/src/helpers/parse_snak.ts
+++ b/src/helpers/parse_snak.ts
@@ -108,7 +108,7 @@ for (const [ datatype, parser ] of Object.entries(parsers)) {
   normalizedParsers[normalizeDatatype(datatype)] = parser
 }
 
-export function parseSnak (datatype: DataType | void, datavalue: SnakValue, options: SimplifySnakOptions) {
+export function parseSnak (datatype: DataType | undefined, datavalue: SnakValue, options: SimplifySnakOptions) {
   // @ts-expect-error Known case of missing datatype: form.claims, sense.claims, mediainfo.statements
   datatype = datatype || datavalue.type
 

--- a/src/helpers/parse_snak.ts
+++ b/src/helpers/parse_snak.ts
@@ -1,5 +1,8 @@
 import { wikibaseTimeToEpochTime, wikibaseTimeToISOString, wikibaseTimeToSimpleDay } from './time.js'
 import type { TimeInputValue } from './time.js'
+import type { DataType } from '../types/claim.js'
+import type { SimplifySnakOptions } from '../types/simplify_claims.js'
+import type { SnakValue } from '../types/snakvalue.js'
 
 const simple = datavalue => datavalue.value
 
@@ -105,9 +108,9 @@ for (const [ datatype, parser ] of Object.entries(parsers)) {
   normalizedParsers[normalizeDatatype(datatype)] = parser
 }
 
-export function parseSnak (datatype, datavalue, options) {
+export function parseSnak (datatype: DataType | void, datavalue: SnakValue, options: SimplifySnakOptions) {
   // Known case of missing datatype: form.claims, sense.claims, mediainfo.statements
-  datatype = datatype || datavalue.type
+  datatype = (datatype || datavalue.type) as DataType
 
   try {
     // Known case requiring normalization

--- a/src/helpers/parse_snak.ts
+++ b/src/helpers/parse_snak.ts
@@ -114,7 +114,7 @@ export function parseSnak (datatype: DataType | void, datavalue: SnakValue, opti
 
   try {
     // Known case requiring normalization
-    // - legacy "muscial notation" datatype
+    // - legacy "musical notation" datatype
     // - mediainfo won't have datatype="globe-coordinate", but datavalue.type="globecoordinate"
     const parser = normalizedParsers[normalizeDatatype(datatype)]
     return parser(datavalue, options)

--- a/src/helpers/parse_snak.ts
+++ b/src/helpers/parse_snak.ts
@@ -112,17 +112,12 @@ export function parseSnak (datatype: DataType | void, datavalue: SnakValue, opti
   // @ts-expect-error Known case of missing datatype: form.claims, sense.claims, mediainfo.statements
   datatype = datatype || datavalue.type
 
-  try {
-    // Known case requiring normalization
-    // - legacy "musical notation" datatype
-    // - mediainfo won't have datatype="globe-coordinate", but datavalue.type="globecoordinate"
-    const parser = normalizedParsers[normalizeDatatype(datatype)]
-    return parser(datavalue, options)
-  } catch (err) {
-    if (err.message === 'parsers[datatype] is not a function') {
-      err.message = `${datatype} claim parser isn't implemented
-      Please report to https://github.com/maxlath/wikibase-sdk/issues`
-    }
-    throw err
+  // Known case requiring normalization
+  // - legacy "musical notation" datatype
+  // - mediainfo won't have datatype="globe-coordinate", but datavalue.type="globecoordinate"
+  const parser = normalizedParsers[normalizeDatatype(datatype)]
+  if (!parser) {
+    throw new Error(`${normalizeDatatype(datatype)} claim parser isn't implemented. Please report to https://github.com/maxlath/wikibase-sdk/issues`)
   }
+  return parser(datavalue, options)
 }

--- a/src/helpers/parse_snak.ts
+++ b/src/helpers/parse_snak.ts
@@ -109,8 +109,8 @@ for (const [ datatype, parser ] of Object.entries(parsers)) {
 }
 
 export function parseSnak (datatype: DataType | void, datavalue: SnakValue, options: SimplifySnakOptions) {
-  // Known case of missing datatype: form.claims, sense.claims, mediainfo.statements
-  datatype = (datatype || datavalue.type) as DataType
+  // @ts-expect-error Known case of missing datatype: form.claims, sense.claims, mediainfo.statements
+  datatype = datatype || datavalue.type
 
   try {
     // Known case requiring normalization

--- a/src/helpers/simplify.ts
+++ b/src/helpers/simplify.ts
@@ -5,7 +5,9 @@ export {
   simplifyPropertyQualifiers as propertyQualifiers,
   simplifyQualifier as qualifier,
   simplifyQualifiers as qualifiers,
+  simplifyReference as reference,
   simplifyReferences as references,
+  simplifySnak as snak,
 } from './simplify_claims.js'
 export {
   simplifyForm as form,
@@ -29,10 +31,3 @@ export {
   simplifyEntities as entities,
   simplifyEntity as entity,
 } from './simplify_entity.js'
-
-// Aliases
-export {
-  simplifyClaim as snak,
-  simplifyClaims as snaks,
-  simplifyPropertyClaims as propertySnaks,
-} from './simplify_claims.js'

--- a/src/helpers/simplify_claims.ts
+++ b/src/helpers/simplify_claims.ts
@@ -153,6 +153,8 @@ export function simplifyReference (reference: Reference, options: SimplifySnaksO
   if (options.keepHashes) return { snaks, hash: reference.hash }
   else return snaks
 }
+/** @deprecated use the new function name simplifyReference instead */
+export const simplifyReferenceRecord = simplifyReference
 
 const keepOptions = [ 'keepQualifiers', 'keepReferences', 'keepIds', 'keepHashes', 'keepTypes', 'keepSnaktypes', 'keepRanks', 'keepRichValues' ] as const
 

--- a/src/helpers/simplify_claims.ts
+++ b/src/helpers/simplify_claims.ts
@@ -154,7 +154,7 @@ export function simplifyReference (reference: Reference, options: SimplifySnaksO
   else return snaks
 }
 
-const keepOptions = [ 'keepQualifiers', 'keepReferences', 'keepIds', 'keepHashes', 'keepTypes', 'keepSnaktypes', 'keepRanks', 'keepRichValues' ]
+const keepOptions = [ 'keepQualifiers', 'keepReferences', 'keepIds', 'keepHashes', 'keepTypes', 'keepSnaktypes', 'keepRanks', 'keepRichValues' ] as const
 
 const parseKeepOptions = (options: any = {}) => {
   if (options.keepAll) {

--- a/src/helpers/simplify_claims.ts
+++ b/src/helpers/simplify_claims.ts
@@ -107,19 +107,27 @@ export function simplifyPropertySnaks (propertySnaks: PropertySnaks, options: Si
   return applyArraySimplification(propertySnaks, simplifySnak, options)
 }
 
-function applyObjectSimplification (obj, fn, options) {
+function applyObjectSimplification (
+  obj: Claims | Snaks,
+  simplifyFn: typeof simplifyPropertyClaims | typeof simplifyPropertySnaks,
+  options: SimplifyClaimsOptions | SimplifySnaksOptions,
+) {
   const { propertyPrefix } = options
   const simplified = {}
   for (let [ propertyId, propertyArray ] of Object.entries(obj)) {
     if (propertyPrefix) {
       propertyId = propertyPrefix + ':' + propertyId
     }
-    simplified[propertyId] = fn(propertyArray, options)
+    simplified[propertyId] = simplifyFn(propertyArray, options)
   }
   return simplified
 }
 
-function applyArraySimplification (array, simplifyFn, options) {
+function applyArraySimplification (
+  array: PropertyClaims | PropertySnaks,
+  simplifyFn: typeof simplifyClaim | typeof simplifySnak,
+  options: SimplifyClaimsOptions | SimplifySnaksOptions,
+) {
   const simplifiedArray = array
     .map(claimOrSnak => simplifyFn(claimOrSnak, options))
     // Filter-out novalue and somevalue claims,

--- a/src/helpers/simplify_claims.ts
+++ b/src/helpers/simplify_claims.ts
@@ -1,9 +1,8 @@
 import { isPlainObject, uniq } from '../utils/utils.js'
 import { parseSnak } from './parse_snak.js'
 import { truthyPropertyClaims, nonDeprecatedPropertyClaims } from './rank.js'
-import type { CustomSimplifiedClaim } from '../index.js'
 import type { Claim, Claims, PropertyClaims, PropertyQualifiers, PropertySnaks, Qualifier, Qualifiers, Reference, Snak, Snaks } from '../types/claim.js'
-import type { CustomSimplifiedSnak, SimplifiedClaim, SimplifiedClaims, SimplifiedPropertyClaims, SimplifiedPropertySnaks, SimplifiedSnaks, SimplifyClaimsOptions, SimplifySnakOptions, SimplifySnaksOptions } from '../types/simplify_claims.js'
+import type { CustomSimplifiedClaim, CustomSimplifiedSnak, SimplifiedClaim, SimplifiedClaims, SimplifiedPropertyClaims, SimplifiedPropertySnaks, SimplifiedSnaks, SimplifyClaimsOptions, SimplifySnakOptions, SimplifySnaksOptions } from '../types/simplify_claims.js'
 
 /**
  * Tries to replace wikidata deep snak object by a simple value
@@ -113,7 +112,7 @@ function applyObjectSimplification (
   options: SimplifyClaimsOptions | SimplifySnaksOptions,
 ) {
   const { propertyPrefix } = options
-  const simplified = {}
+  const simplified: SimplifiedClaims | SimplifiedSnaks = {}
   for (let [ propertyId, propertyArray ] of Object.entries(obj)) {
     if (propertyPrefix) {
       propertyId = propertyPrefix + ':' + propertyId

--- a/src/helpers/simplify_claims.ts
+++ b/src/helpers/simplify_claims.ts
@@ -54,7 +54,7 @@ export function simplifyClaim (claim: Claim, options: SimplifySnakOptions = {}):
   }
 
   // When keeping other attributes, the value becomes an object instead of a direct value
-  let valueObj
+  let valueObj: CustomSimplifiedClaim
   if (isPlainObject(value)) {
     valueObj = value as CustomSimplifiedClaim
   } else {

--- a/src/helpers/simplify_claims.ts
+++ b/src/helpers/simplify_claims.ts
@@ -1,126 +1,75 @@
-import { uniq } from '../utils/utils.js'
-import { parseClaim } from './parse_claim.js'
+import { isPlainObject, uniq } from '../utils/utils.js'
+import { parseSnak } from './parse_snak.js'
 import { truthyPropertyClaims, nonDeprecatedPropertyClaims } from './rank.js'
-import type { Claim, Claims, PropertyClaims, PropertyQualifiers, Qualifier, Qualifiers, Reference } from '../types/claim.js'
-import type { SimplifiedClaim, SimplifiedClaims, SimplifiedPropertyClaims, SimplifySnakOptions, SimplifySnaksOptions } from '../types/simplify_claims.js'
+import type { CustomSimplifiedClaim } from '../index.js'
+import type { Claim, Claims, PropertyClaims, PropertyQualifiers, PropertySnaks, Qualifier, Qualifiers, Reference, Snak, Snaks } from '../types/claim.js'
+import type { CustomSimplifiedSnak, SimplifiedClaim, SimplifiedClaims, SimplifiedPropertyClaims, SimplifiedPropertySnaks, SimplifiedSnaks, SimplifyClaimsOptions, SimplifySnakOptions, SimplifySnaksOptions } from '../types/simplify_claims.js'
 
-export function simplifySnaks (snaks, options) {
-  const { propertyPrefix } = options
-  const simplifiedSnaks: any = {}
-  for (let id in snaks) {
-    const propertySnaks = snaks[id]
-    if (propertyPrefix) {
-      id = propertyPrefix + ':' + id
-    }
-    simplifiedSnaks[id] = simplifyPropertySnaks(propertySnaks, options)
-  }
-  return simplifiedSnaks
-}
+/**
+ * Tries to replace wikidata deep snak object by a simple value
+ * e.g. a string, an entity Qid or an epoch time number
+ * Expects a single snak object
+ * Ex: entity.claims.P369[0]
+ */
+export function simplifySnak (snak: Snak, options: SimplifySnakOptions = {}) {
+  const { keepTypes, keepSnaktypes, keepHashes } = parseKeepOptions(options)
 
-export function simplifyPropertySnaks (propertySnaks, options) {
-  // Avoid to throw on empty inputs to allow to simplify claims array
-  // without having to know if the entity as claims for this property
-  // Ex: simplifyPropertyClaims(entity.claims.P124211616)
-  if (propertySnaks == null || propertySnaks.length === 0) return []
-
-  const { keepNonTruthy, keepNonDeprecated, areSubSnaks } = parseKeepOptions(options)
-
-  if (keepNonDeprecated) {
-    propertySnaks = nonDeprecatedPropertyClaims(propertySnaks)
-  } else if (!(keepNonTruthy || areSubSnaks)) {
-    propertySnaks = truthyPropertyClaims(propertySnaks)
-  }
-
-  propertySnaks = propertySnaks
-    .map(claim => simplifyClaim(claim, options))
-    // Filter-out novalue and somevalue claims,
-    // unless a novalueValue or a somevalueValue is passed in options
-    // Considers null as defined
-    .filter(obj => obj !== undefined)
-
-  // Deduplicate values unless we return a rich value object
-  if (propertySnaks[0] && typeof propertySnaks[0] !== 'object') {
-    return uniq(propertySnaks)
-  } else {
-    return propertySnaks
-  }
-}
-
-// Expects a single snak object
-// Ex: entity.claims.P369[0]
-export function simplifySnak (claim, options) {
-  const { keepQualifiers, keepReferences, keepIds, keepHashes, keepTypes, keepSnaktypes, keepRanks } = parseKeepOptions(options)
-
-  // tries to replace wikidata deep claim object by a simple value
-  // e.g. a string, an entity Qid or an epoch time number
-  const { mainsnak, rank } = claim
-
-  let value, datatype, datavalue, snaktype, isQualifierSnak, isReferenceSnak
-  if (mainsnak) {
-    datatype = mainsnak.datatype
-    datavalue = mainsnak.datavalue
-    snaktype = mainsnak.snaktype
-  } else {
-    // Qualifiers have no mainsnak, and define datatype, datavalue on claim
-    datavalue = claim.datavalue
-    datatype = claim.datatype
-    snaktype = claim.snaktype
-    // Duck typing the sub-snak type
-    if (claim.hash) isQualifierSnak = true
-    else isReferenceSnak = true
-  }
+  let value
+  const { datatype, datavalue, snaktype, hash } = snak
 
   if (datavalue) {
-    value = parseClaim(datatype, datavalue, options, claim.id)
+    value = parseSnak(datatype, datavalue, options)
   } else {
     if (snaktype === 'somevalue') value = options.somevalueValue
     else if (snaktype === 'novalue') value = options.novalueValue
     else throw new Error('no datavalue or special snaktype found')
   }
 
-  // Qualifiers should not attempt to keep sub-qualifiers or references
-  if (isQualifierSnak) {
-    if (!(keepHashes || keepTypes || keepSnaktypes)) return value
-
-    const valueObj: any = { value }
-
-    if (keepHashes) valueObj.hash = claim.hash
+  // No need to test keepHashes as it has no effect if neither
+  // keepQualifiers or keepReferences is true
+  if (keepTypes || keepSnaktypes || keepHashes) {
+    // When keeping qualifiers or references, the value becomes an object
+    // instead of a direct value
+    const valueObj: CustomSimplifiedSnak = { value }
     if (keepTypes) valueObj.type = datatype
     if (keepSnaktypes) valueObj.snaktype = snaktype
-
+    if (keepHashes) valueObj.hash = hash
     return valueObj
+  } else {
+    return value
   }
-  if (isReferenceSnak) {
-    if (!keepTypes) return value
+}
 
-    return { type: datatype, value }
-  }
+export function simplifyClaim (claim: Claim, options: SimplifySnakOptions = {}): SimplifiedClaim {
+  const { keepQualifiers, keepReferences, keepIds, keepTypes, keepSnaktypes, keepRanks } = parseKeepOptions(options)
+
+  const { mainsnak, rank } = claim
+
+  const value = simplifySnak(mainsnak, options)
+
   // No need to test keepHashes as it has no effect if neither
   // keepQualifiers or keepReferences is true
   if (!(keepQualifiers || keepReferences || keepIds || keepTypes || keepSnaktypes || keepRanks)) {
     return value
   }
 
-  // When keeping qualifiers or references, the value becomes an object
-  // instead of a direct value
-  const valueObj: any = { value }
-
-  if (keepTypes) valueObj.type = datatype
-
-  if (keepSnaktypes) valueObj.snaktype = snaktype
+  // When keeping other attributes, the value becomes an object instead of a direct value
+  let valueObj
+  if (isPlainObject(value)) {
+    valueObj = value as CustomSimplifiedClaim
+  } else {
+    valueObj = { value } as CustomSimplifiedClaim
+  }
 
   if (keepRanks) valueObj.rank = rank
 
-  const subSnaksOptions = getSubSnakOptions(options)
-  subSnaksOptions.keepHashes = keepHashes
-
   if (keepQualifiers) {
-    valueObj.qualifiers = simplifyQualifiers(claim.qualifiers, subSnaksOptions)
+    valueObj.qualifiers = simplifyQualifiers(claim.qualifiers, options)
   }
 
   if (keepReferences) {
     claim.references = claim.references || []
-    valueObj.references = simplifyReferences(claim.references, subSnaksOptions)
+    valueObj.references = simplifyReferences(claim.references, options)
   }
 
   if (keepIds) valueObj.id = claim.id
@@ -128,49 +77,90 @@ export function simplifySnak (claim, options) {
   return valueObj
 }
 
-export function simplifyClaims (claims: Claims, options: SimplifySnaksOptions = {}): SimplifiedClaims {
-  return simplifySnaks(claims, options)
+export function simplifyClaims (claims: Claims, options: SimplifyClaimsOptions = {}): SimplifiedClaims {
+  return applyObjectSimplification(claims, simplifyPropertyClaims, options)
 }
-export function simplifyPropertyClaims (propertyClaims: PropertyClaims, options: SimplifySnaksOptions = {}): SimplifiedPropertyClaims {
-  return simplifyPropertySnaks(propertyClaims, options)
+
+export function simplifyPropertyClaims (propertyClaims: PropertyClaims, options: SimplifyClaimsOptions = {}): SimplifiedPropertyClaims {
+  // Avoid to throw on empty inputs to allow to simplify claims array
+  // without having to know if the entity as claims for this property
+  // Ex: simplifyPropertyClaims(entity.claims.P124211616)
+  if (propertyClaims == null || propertyClaims.length === 0) return []
+
+  const { keepNonTruthy, keepNonDeprecated } = parseKeepOptions(options)
+
+  if (keepNonDeprecated) {
+    propertyClaims = nonDeprecatedPropertyClaims(propertyClaims)
+  } else if (!(keepNonTruthy)) {
+    propertyClaims = truthyPropertyClaims(propertyClaims)
+  }
+
+  return applyArraySimplification(propertyClaims, simplifyClaim, options)
 }
-export function simplifyClaim (claim: Claim, options: SimplifySnakOptions = {}): SimplifiedClaim {
-  return simplifySnak(claim, options)
+
+export function simplifySnaks (snaks: Snaks = {}, options: SimplifySnaksOptions = {}): SimplifiedSnaks {
+  return applyObjectSimplification(snaks, simplifyPropertySnaks, options)
+}
+
+export function simplifyPropertySnaks (propertySnaks: PropertySnaks, options: SimplifySnaksOptions = {}): SimplifiedPropertySnaks {
+  if (propertySnaks == null || propertySnaks.length === 0) return []
+  return applyArraySimplification(propertySnaks, simplifySnak, options)
+}
+
+function applyObjectSimplification (obj, fn, options) {
+  const { propertyPrefix } = options
+  const simplified = {}
+  for (let [ propertyId, propertyArray ] of Object.entries(obj)) {
+    if (propertyPrefix) {
+      propertyId = propertyPrefix + ':' + propertyId
+    }
+    simplified[propertyId] = fn(propertyArray, options)
+  }
+  return simplified
+}
+
+function applyArraySimplification (array, simplifyFn, options) {
+  const simplifiedArray = array
+    .map(claimOrSnak => simplifyFn(claimOrSnak, options))
+    // Filter-out novalue and somevalue claims,
+    // unless a novalueValue or a somevalueValue is passed in options
+    // Considers null as defined
+    .filter(obj => obj !== undefined)
+
+  // Deduplicate values unless we return a rich value object
+  if (simplifiedArray[0] && typeof simplifiedArray[0] !== 'object') {
+    return uniq(simplifiedArray)
+  } else {
+    return simplifiedArray
+  }
 }
 
 export function simplifyQualifiers (qualifiers: Qualifiers, options: SimplifySnaksOptions = {}) {
-  return simplifySnaks(qualifiers, getSubSnakOptions(options))
+  return simplifySnaks(qualifiers, options)
 }
 export function simplifyPropertyQualifiers (propertyQualifiers: PropertyQualifiers, options: SimplifySnaksOptions = {}) {
-  return simplifyPropertySnaks(propertyQualifiers, getSubSnakOptions(options))
+  return simplifyPropertySnaks(propertyQualifiers, options)
 }
 export function simplifyQualifier (qualifier: Qualifier, options: SimplifySnakOptions = {}) {
   return simplifySnak(qualifier, options)
 }
 
-export function simplifyReferences (references: readonly Reference[], options: any = {}) {
-  return references.map(refRecord => simplifyReferenceRecord(refRecord, options))
+export function simplifyReferences (references: readonly Reference[], options: SimplifySnaksOptions = {}) {
+  return references.map(reference => simplifyReference(reference, options))
 }
-export function simplifyReferenceRecord (refRecord: Reference, options: any = {}) {
-  const subSnaksOptions = getSubSnakOptions(options)
-  const snaks = simplifySnaks(refRecord.snaks, subSnaksOptions)
-  if (subSnaksOptions.keepHashes) return { snaks, hash: refRecord.hash }
+export function simplifyReference (reference: Reference, options: SimplifySnaksOptions = {}) {
+  const snaks = simplifySnaks(reference.snaks, options)
+  if (options.keepHashes) return { snaks, hash: reference.hash }
   else return snaks
-}
-
-const getSubSnakOptions = (options: any = {}) => {
-  if (options.areSubSnaks) return options
-  // Using a new object so that the original options object isn't modified
-  else return Object.assign({}, options, { areSubSnaks: true })
 }
 
 const keepOptions = [ 'keepQualifiers', 'keepReferences', 'keepIds', 'keepHashes', 'keepTypes', 'keepSnaktypes', 'keepRanks', 'keepRichValues' ]
 
 const parseKeepOptions = (options: any = {}) => {
   if (options.keepAll) {
-    keepOptions.forEach(optionName => {
+    for (const optionName of keepOptions) {
       if (options[optionName] == null) options[optionName] = true
-    })
+    }
   }
   return options
 }

--- a/src/types/claim.ts
+++ b/src/types/claim.ts
@@ -1,6 +1,6 @@
 import type { PropertyId } from './entity.js'
 import type { SnakValue } from './snakvalue.js'
-import type { parsers } from '../helpers/parse_claim.js'
+import type { parsers } from '../helpers/parse_snak.js'
 
 export type Rank = 'normal' | 'preferred' | 'deprecated'
 export type SnakType = 'value' | 'somevalue' | 'novalue'

--- a/src/types/claim.ts
+++ b/src/types/claim.ts
@@ -4,7 +4,9 @@ import type { parsers } from '../helpers/parse_snak.js'
 
 export type Rank = 'normal' | 'preferred' | 'deprecated'
 export type SnakType = 'value' | 'somevalue' | 'novalue'
-export type DataType = keyof typeof parsers
+
+export type InconsistentDataType = 'globecoordinate' | 'musical notation'
+export type DataType = keyof typeof parsers | InconsistentDataType
 
 export interface Claim {
   id: Guid

--- a/src/types/claim.ts
+++ b/src/types/claim.ts
@@ -5,8 +5,7 @@ import type { parsers } from '../helpers/parse_snak.js'
 export type Rank = 'normal' | 'preferred' | 'deprecated'
 export type SnakType = 'value' | 'somevalue' | 'novalue'
 
-export type InconsistentDataType = 'globecoordinate' | 'musical notation'
-export type DataType = keyof typeof parsers | InconsistentDataType
+export type DataType = keyof typeof parsers
 
 export interface Claim {
   id: Guid

--- a/src/types/claim.ts
+++ b/src/types/claim.ts
@@ -1,4 +1,4 @@
-import type { PropertyId } from './entity.js'
+import type { Guid, PropertyId } from './entity.js'
 import type { SnakValue } from './snakvalue.js'
 import type { parsers } from '../helpers/parse_snak.js'
 
@@ -7,7 +7,7 @@ export type SnakType = 'value' | 'somevalue' | 'novalue'
 export type DataType = keyof typeof parsers
 
 export interface Claim {
-  id: string
+  id: Guid
   mainsnak: Snak
   rank: Rank
   type: 'statement'

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,4 +1,4 @@
-import type { SimplifySnaksOptions } from './simplify_claims.js'
+import type { SimplifyClaimsOptions } from './simplify_claims.js'
 
 export interface InstanceConfig {
   instance?: string
@@ -11,7 +11,7 @@ export type UrlResultFormat = 'xml' | 'json'
 
 export type LanguageCode = string
 
-export interface SimplifyEntityOptions extends SimplifySnaksOptions, SimplifySitelinkOptions {}
+export interface SimplifyEntityOptions extends SimplifyClaimsOptions, SimplifySitelinkOptions {}
 
 export interface SimplifySitelinkOptions {
   addUrl?: boolean

--- a/src/types/simplify_claims.ts
+++ b/src/types/simplify_claims.ts
@@ -1,6 +1,6 @@
-import type { DataType, Rank } from './claim.js'
-import type { Guid, PropertyId } from './entity.js'
-import type { timeConverters } from '../helpers/parse_claim.js'
+import type { DataType, Rank, SnakType } from './claim.js'
+import type { Guid, Hash, PropertyId } from './entity.js'
+import type { timeConverters } from '../helpers/parse_snak.js'
 
 export interface SimplifySnakOptions {
   entityPrefix?: string
@@ -9,9 +9,7 @@ export interface SimplifySnakOptions {
   keepTypes?: boolean
   keepQualifiers?: boolean
   keepReferences?: boolean
-  keepIds?: boolean
   keepHashes?: boolean
-  keepRanks?: boolean
   keepSnaktypes?: boolean
   keepAll?: boolean
   timeConverter?: keyof typeof timeConverters
@@ -19,15 +17,17 @@ export interface SimplifySnakOptions {
   somevalueValue?: any
 }
 
-export interface SimplifySnaksOptions extends SimplifySnakOptions {
+export type SimplifySnaksOptions = SimplifySnakOptions
+
+export interface SimplifyClaimsOptions extends SimplifySnaksOptions {
+  keepIds?: boolean
+  keepRanks?: boolean
   keepNonTruthy?: boolean
   keepNonDeprecated?: boolean
 }
 
-export type SimplifyClaimsOptions = SimplifySnaksOptions
-
 export interface CustomSimplifiedClaim extends CustomSimplifiedSnak {
-  id: Guid
+  id?: Guid
   rank?: Rank
   qualifiers?: SimplifiedQualifiers
   references?: SimplifiedReferences
@@ -54,7 +54,8 @@ export type SimplifiedSnak = string | number | CustomSimplifiedSnak
 export type SimplifiedClaim = string | number | CustomSimplifiedClaim
 
 export interface CustomSimplifiedSnak {
-  id: string
   type?: DataType
   value: unknown
+  snaktype?: SnakType
+  hash?: Hash
 }

--- a/src/types/simplify_claims.ts
+++ b/src/types/simplify_claims.ts
@@ -45,9 +45,18 @@ export interface SimplifiedQualifiers {
 }
 
 export type SimplifiedReferenceSnak = SimplifiedSnak
-export interface SimplifiedReference {
-  [property: string]: SimplifiedReferenceSnak
+
+export interface SimplifiedReferenceSnaks {
+  [property: string]: SimplifiedReferenceSnak[]
 }
+
+export interface RichSimplifiedReferenceSnaks {
+  snaks: SimplifiedReferenceSnaks
+  hash: Hash
+}
+
+export type SimplifiedReference = SimplifiedReferenceSnaks | RichSimplifiedReferenceSnaks
+
 export type SimplifiedReferences = SimplifiedReference[]
 
 export type SimplifiedSnak = string | number | CustomSimplifiedSnak

--- a/src/types/simplify_claims.ts
+++ b/src/types/simplify_claims.ts
@@ -46,9 +46,7 @@ export interface SimplifiedQualifiers {
 
 export type SimplifiedReferenceSnak = SimplifiedSnak
 
-export interface SimplifiedReferenceSnaks {
-  [property: string]: SimplifiedReferenceSnak[]
-}
+export type SimplifiedReferenceSnaks = Record<PropertyId, SimplifiedReferenceSnak[]>
 
 export interface RichSimplifiedReferenceSnaks {
   snaks: SimplifiedReferenceSnaks

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -21,7 +21,7 @@ export function forceArray<T extends string> (array: T | readonly T[] | undefine
   return []
 }
 
-/** simplistic implementation to filter-out arrays */
+/** simplistic implementation to filter-out arrays and null */
 export function isPlainObject (obj: unknown): boolean {
   return Boolean(obj) && typeof obj === 'object' && !Array.isArray(obj)
 }

--- a/tests/data/P3035.json
+++ b/tests/data/P3035.json
@@ -1,0 +1,85 @@
+{
+  "type": "property",
+  "datatype": "external-id",
+  "id": "P3035",
+  "claims": {
+    "P1659": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1659",
+          "hash": "ffa6ce752c4f1e00cfe161c195dc5b2a965a8ac4",
+          "datavalue": {
+            "value": {
+              "entity-type": "property",
+              "numeric-id": 212,
+              "id": "P212"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-property"
+        },
+        "type": "statement",
+        "id": "P3035$65187550-4303-9d66-8519-13fff74a3142",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1659",
+          "hash": "fefeac38320600c91237b7b4bedfca0aa058b863",
+          "datavalue": {
+            "value": {
+              "entity-type": "property",
+              "numeric-id": 957,
+              "id": "P957"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-property"
+        },
+        "type": "statement",
+        "id": "P3035$6cd05825-4a40-94cb-4ccb-6703636eb839",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1659",
+          "hash": "451cc24bbee498bfa2d6f39258b37a04a4a506ef",
+          "datavalue": {
+            "value": {
+              "entity-type": "property",
+              "numeric-id": 3097,
+              "id": "P3097"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-property"
+        },
+        "type": "statement",
+        "id": "P3035$99783d9a-4ec8-57ae-5d7a-9eaea67913c7",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1659",
+          "hash": "704062d782cf04c5fbdab0c305ed210b1bd3c8a3",
+          "datavalue": {
+            "value": {
+              "entity-type": "property",
+              "numeric-id": 3193,
+              "id": "P3193"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-property"
+        },
+        "type": "statement",
+        "id": "P3035$d05c3465-4306-a4ff-890b-cecf2ce4f761",
+        "rank": "normal"
+      }
+    ]
+  }
+}

--- a/tests/data/Q2112.json
+++ b/tests/data/Q2112.json
@@ -1,4064 +1,8259 @@
 {
-    "pageid": 3021,
-    "ns": 0,
-    "title": "Q2112",
-    "lastrevid": 363579534,
-    "modified": "2016-08-12T09:00:51Z",
-    "type": "item",
-    "id": "Q2112",
-    "labels": {
-        "de": {
-            "language": "de",
-            "value": "Bielefeld"
-        },
-        "ru": {
-            "language": "ru",
-            "value": "Билефельд"
-        },
-        "fr": {
-            "language": "fr",
-            "value": "Bielefeld"
-        },
-        "en": {
-            "language": "en",
-            "value": "Bielefeld"
-        },
-        "be-tarask": {
-            "language": "be-tarask",
-            "value": "Білефэльд"
-        },
-        "nan": {
-            "language": "nan",
-            "value": "Bielefeld"
-        },
-        "gv": {
-            "language": "gv",
-            "value": "Bielefeld"
-        },
-        "de-ch": {
-            "language": "de-ch",
-            "value": "Bielefeld"
-        },
-        "en-ca": {
-            "language": "en-ca",
-            "value": "Bielefeld"
-        },
-        "en-gb": {
-            "language": "en-gb",
-            "value": "Bielefeld"
-        },
-        "af": {
-            "language": "af",
-            "value": "Bielefeld"
-        },
-        "ar": {
-            "language": "ar",
-            "value": "بيليفيلد"
-        },
-        "az": {
-            "language": "az",
-            "value": "Bielefeld"
-        },
-        "be": {
-            "language": "be",
-            "value": "Горад Білефельд"
-        },
-        "bg": {
-            "language": "bg",
-            "value": "Билефелд"
-        },
-        "ca": {
-            "language": "ca",
-            "value": "Bielefeld"
-        },
-        "cs": {
-            "language": "cs",
-            "value": "Bielefeld"
-        },
-        "cv": {
-            "language": "cv",
-            "value": "Билефелд"
-        },
-        "cy": {
-            "language": "cy",
-            "value": "Bielefeld"
-        },
-        "da": {
-            "language": "da",
-            "value": "Bielefeld"
-        },
-        "diq": {
-            "language": "diq",
-            "value": "Bielefeld"
-        },
-        "el": {
-            "language": "el",
-            "value": "Μπίλεφελντ"
-        },
-        "eo": {
-            "language": "eo",
-            "value": "Bielefeld"
-        },
-        "es": {
-            "language": "es",
-            "value": "Bielefeld"
-        },
-        "et": {
-            "language": "et",
-            "value": "Bielefeld"
-        },
-        "eu": {
-            "language": "eu",
-            "value": "Bielefeld"
-        },
-        "fa": {
-            "language": "fa",
-            "value": "بیله‌فلد"
-        },
-        "fi": {
-            "language": "fi",
-            "value": "Bielefeld"
-        },
-        "frr": {
-            "language": "frr",
-            "value": "Bielefeld"
-        },
-        "fy": {
-            "language": "fy",
-            "value": "Bielefeld"
-        },
-        "hr": {
-            "language": "hr",
-            "value": "Bielefeld"
-        },
-        "hu": {
-            "language": "hu",
-            "value": "Bielefeld"
-        },
-        "id": {
-            "language": "id",
-            "value": "Bielefeld"
-        },
-        "is": {
-            "language": "is",
-            "value": "Bielefeld"
-        },
-        "it": {
-            "language": "it",
-            "value": "Bielefeld"
-        },
-        "ja": {
-            "language": "ja",
-            "value": "ビーレフェルト"
-        },
-        "ka": {
-            "language": "ka",
-            "value": "ბილეფილდი"
-        },
-        "kk": {
-            "language": "kk",
-            "value": "Билефельд"
-        },
-        "ko": {
-            "language": "ko",
-            "value": "빌레펠트"
-        },
-        "ksh": {
-            "language": "ksh",
-            "value": "Bielefeld"
-        },
-        "ku": {
-            "language": "ku",
-            "value": "Bielefeld"
-        },
-        "la": {
-            "language": "la",
-            "value": "Bilivelda"
-        },
-        "lt": {
-            "language": "lt",
-            "value": "Bylefeldas"
-        },
-        "lv": {
-            "language": "lv",
-            "value": "Bīlefelde"
-        },
-        "mr": {
-            "language": "mr",
-            "value": "बीलेफेल्ड"
-        },
-        "nds": {
-            "language": "nds",
-            "value": "Builefeld"
-        },
-        "nl": {
-            "language": "nl",
-            "value": "Bielefeld"
-        },
-        "nn": {
-            "language": "nn",
-            "value": "Bielefeld"
-        },
-        "oc": {
-            "language": "oc",
-            "value": "Bielefeld"
-        },
-        "pl": {
-            "language": "pl",
-            "value": "Bielefeld"
-        },
-        "pnb": {
-            "language": "pnb",
-            "value": "بیلفیلڈ"
-        },
-        "pt": {
-            "language": "pt",
-            "value": "Bielefeld"
-        },
-        "pt-br": {
-            "language": "pt-br",
-            "value": "Bielefeld"
-        },
-        "ro": {
-            "language": "ro",
-            "value": "Bielefeld"
-        },
-        "sk": {
-            "language": "sk",
-            "value": "Bielefeld"
-        },
-        "sr": {
-            "language": "sr",
-            "value": "Билефелд"
-        },
-        "sv": {
-            "language": "sv",
-            "value": "Bielefeld"
-        },
-        "sw": {
-            "language": "sw",
-            "value": "Bielefeld"
-        },
-        "tr": {
-            "language": "tr",
-            "value": "Bielefeld"
-        },
-        "uk": {
-            "language": "uk",
-            "value": "Білефельд"
-        },
-        "uz": {
-            "language": "uz",
-            "value": "Bielefeld"
-        },
-        "vi": {
-            "language": "vi",
-            "value": "Bielefeld"
-        },
-        "vo": {
-            "language": "vo",
-            "value": "Bielefeld"
-        },
-        "war": {
-            "language": "war",
-            "value": "Bielefeld"
-        },
-        "zh": {
-            "language": "zh",
-            "value": "比勒费尔德"
-        },
-        "nb": {
-            "language": "nb",
-            "value": "Bielefeld"
-        },
-        "gl": {
-            "language": "gl",
-            "value": "Bielefeld"
-        },
-        "stq": {
-            "language": "stq",
-            "value": "Bielefeld"
-        },
-        "he": {
-            "language": "he",
-            "value": "בילפלד"
-        },
-        "bar": {
-            "language": "bar",
-            "value": "Bielefeld"
-        },
-        "sh": {
-            "language": "sh",
-            "value": "Bielefeld"
-        },
-        "sco": {
-            "language": "sco",
-            "value": "Bielefeld"
-        },
-        "hy": {
-            "language": "hy",
-            "value": "Բիլեֆելդ"
-        },
-        "mn": {
-            "language": "mn",
-            "value": "Билефельд"
-        },
-        "mk": {
-            "language": "mk",
-            "value": "Билефелд"
-        },
-        "an": {
-            "language": "an",
-            "value": "Bielefeld"
-        },
-        "ast": {
-            "language": "ast",
-            "value": "Bielefeld"
-        },
-        "br": {
-            "language": "br",
-            "value": "Bielefeld"
-        },
-        "co": {
-            "language": "co",
-            "value": "Bielefeld"
-        },
-        "de-at": {
-            "language": "de-at",
-            "value": "Bielefeld"
-        },
-        "frp": {
-            "language": "frp",
-            "value": "Bielefeld"
-        },
-        "fur": {
-            "language": "fur",
-            "value": "Bielefeld"
-        },
-        "ga": {
-            "language": "ga",
-            "value": "Bielefeld"
-        },
-        "gd": {
-            "language": "gd",
-            "value": "Bielefeld"
-        },
-        "gsw": {
-            "language": "gsw",
-            "value": "Bielefeld"
-        },
-        "ia": {
-            "language": "ia",
-            "value": "Bielefeld"
-        },
-        "ie": {
-            "language": "ie",
-            "value": "Bielefeld"
-        },
-        "io": {
-            "language": "io",
-            "value": "Bielefeld"
-        },
-        "kg": {
-            "language": "kg",
-            "value": "Bielefeld"
-        },
-        "lb": {
-            "language": "lb",
-            "value": "Bielefeld"
-        },
-        "li": {
-            "language": "li",
-            "value": "Bielefeld"
-        },
-        "lij": {
-            "language": "lij",
-            "value": "Bielefeld"
-        },
-        "mg": {
-            "language": "mg",
-            "value": "Bielefeld"
-        },
-        "min": {
-            "language": "min",
-            "value": "Bielefeld"
-        },
-        "ms": {
-            "language": "ms",
-            "value": "Bielefeld"
-        },
-        "nap": {
-            "language": "nap",
-            "value": "Bielefeld"
-        },
-        "nds-nl": {
-            "language": "nds-nl",
-            "value": "Bielefeld"
-        },
-        "nrm": {
-            "language": "nrm",
-            "value": "Bielefeld"
-        },
-        "pcd": {
-            "language": "pcd",
-            "value": "Bielefeld"
-        },
-        "pms": {
-            "language": "pms",
-            "value": "Bielefeld"
-        },
-        "rm": {
-            "language": "rm",
-            "value": "Bielefeld"
-        },
-        "sc": {
-            "language": "sc",
-            "value": "Bielefeld"
-        },
-        "scn": {
-            "language": "scn",
-            "value": "Bielefeld"
-        },
-        "sl": {
-            "language": "sl",
-            "value": "Bielefeld"
-        },
-        "sr-el": {
-            "language": "sr-el",
-            "value": "Bielefeld"
-        },
-        "vec": {
-            "language": "vec",
-            "value": "Bielefeld"
-        },
-        "vls": {
-            "language": "vls",
-            "value": "Bielefeld"
-        },
-        "wa": {
-            "language": "wa",
-            "value": "Bielefeld"
-        },
-        "wo": {
-            "language": "wo",
-            "value": "Bielefeld"
-        },
-        "zu": {
-            "language": "zu",
-            "value": "Bielefeld"
-        },
-        "ur": {
-            "language": "ur",
-            "value": "بیئلفیلڈ"
-        },
-        "szl": {
-            "language": "szl",
-            "value": "Bielefeld"
-        },
-        "th": {
-            "language": "th",
-            "value": "บีเลอเฟลด์"
-        },
-        "hsb": {
-            "language": "hsb",
-            "value": "Bielefeld"
-        },
-        "ceb": {
-            "language": "ceb",
-            "value": "Bielefeld (kapital sa munisipyo)"
-        },
-        "ky": {
-            "language": "ky",
-            "value": "Билефельд"
-        },
-        "tt": {
-            "language": "tt",
-            "value": "Билефелд"
-        }
+  "pageid": 3021,
+  "ns": 0,
+  "title": "Q2112",
+  "lastrevid": 1867923350,
+  "modified": "2023-04-04T05:21:49Z",
+  "type": "item",
+  "id": "Q2112",
+  "labels": {
+    "de": {
+      "language": "de",
+      "value": "Bielefeld"
     },
-    "descriptions": {
-        "de": {
-            "language": "de",
-            "value": "Großstadt in Nordrhein-Westfalen, Deutschland"
-        },
-        "en": {
-            "language": "en",
-            "value": "city in Germany"
-        },
-        "es": {
-            "language": "es",
-            "value": "ciudad independiente alemana en Renania del Norte-Westfalia"
-        },
-        "it": {
-            "language": "it",
-            "value": "città extracircondariale tedesca"
-        },
-        "fr": {
-            "language": "fr",
-            "value": "commune allemande"
-        },
-        "ru": {
-            "language": "ru",
-            "value": "город в Германии"
-        },
-        "el": {
-            "language": "el",
-            "value": "πόλη της Γερμανίας, στην Βόρεια Ρηνανία-Βεστφαλία"
-        },
-        "ne": {
-            "language": "ne",
-            "value": "जर्मनीको सहर"
-        },
-        "nl": {
-            "language": "nl",
-            "value": "gemeente in Noordrijn-Westfalen, Duitsland"
-        }
+    "ru": {
+      "language": "ru",
+      "value": "Билефельд"
     },
-    "aliases": {
-        "de": [
-            {
-                "language": "de",
-                "value": "Leineweberstadt"
-            }
-        ]
+    "fr": {
+      "language": "fr",
+      "value": "Bielefeld"
     },
-    "claims": {
-        "P123456789": [
-            {
-                "mainsnak": {
-                    "comment": "THIS IS A FAKE CLAIM TO TEST PROPERTY VALUES",
-                    "snaktype": "value",
-                    "property": "P123456789",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "property",
-                            "numeric-id": 207614,
-                            "id": "P207614"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-property"
-                },
-                "type": "statement",
-                "id": "Q2112$71781c61-47f7-e370-893c-11f7efe421c8",
-                "rank": "normal"
-            }
-        ],
-        "P190": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P190",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 207614,
-                            "id": "Q207614"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$71781c61-47f7-d370-893c-11f7efe421c8",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P190",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 474605,
-                            "id": "Q474605"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "3d22f4dffba1ac6f66f521ea6bea924e46df4129",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1953-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580"
-                ],
-                "id": "Q2112$fa2b9dbe-44c4-e3aa-b1b7-6725768477cf",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P190",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 990109,
-                            "id": "Q990109"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "8875b0ec2e19e95f9a171ddb4b304ee91d61d421",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1958-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580"
-                ],
-                "id": "Q2112$36372432-48e6-04d2-094b-520cb640f72f",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P190",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 17393,
-                            "id": "Q17393"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "1ba8a0f9512b574dde494cb8f16ddfc1a301786a",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1973-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580"
-                ],
-                "id": "Q2112$70276a6c-40fe-b35f-f82c-fd93b04c7259",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P190",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 167749,
-                            "id": "Q167749"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "58ca85434997317a3ea400a5a30da6930df07d77",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1980-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580"
-                ],
-                "id": "Q2112$f77ab273-41c8-96b5-08c1-93af88903cd4",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P190",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 2235,
-                            "id": "Q2235"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "b34e936e1872062824f97cfdbd3ce206d8f0b580",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1987-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580"
-                ],
-                "id": "Q2112$545b65a1-440c-ac9b-2594-8f76c1ffda94",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P190",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 598,
-                            "id": "Q598"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "4d9919a12b5a53700622a0bcbc64d0072a557c7f",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1991-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580"
-                ],
-                "id": "Q2112$8dccc42e-4ede-9f17-8ef5-aee79c88aad3",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P190",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1007634,
-                            "id": "Q1007634"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "1d9b8646f7fc177bcbb691e08753dfedeef27615",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1995-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580"
-                ],
-                "id": "Q2112$500e8510-4d28-e8b4-c9b2-53f109218646",
-                "rank": "normal"
-            }
-        ],
-        "P1036": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1036",
-                    "datavalue": {
-                        "value": "2--435655",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$524f4b4b-46b5-d59c-520b-5eba915a2383",
-                "rank": "normal"
-            }
-        ],
-        "P17": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P17",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 183,
-                            "id": "Q183"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "q2112$15E24192-DD4A-47AC-AE3C-31475E98D6B0",
-                "rank": "normal"
-            }
-        ],
-        "P131": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P131",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 7923,
-                            "id": "Q7923"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "q2112$AFF3F61B-C161-4593-983D-EDB164FF7093",
-                "rank": "normal"
-            }
-        ],
-        "P227": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P227",
-                    "datavalue": {
-                        "value": "4006510-8",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "q2112$F84F5E68-5E71-4070-80FB-8C981C01F92D",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "004ec6fbee857649acdbdbad4f97b2c8571df97b",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 48183,
-                                            "id": "Q48183"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P439": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P439",
-                    "datavalue": {
-                        "value": "05711000",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "q2112$01477795-1D7B-4551-8022-7DFCBFCCF472",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "7eb64cf9621d34c54fd4bd040ed4b61a88c4a1a0",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 328,
-                                            "id": "Q328"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P373": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P373",
-                    "datavalue": {
-                        "value": "Bielefeld",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "q2112$A30D86DE-3888-47EC-A5E9-1FE72DEC6D66",
-                "rank": "normal"
-            }
-        ],
-        "P242": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P242",
-                    "datavalue": {
-                        "value": "North rhine w BI.svg",
-                        "type": "string"
-                    },
-                    "datatype": "commonsMedia"
-                },
-                "type": "statement",
-                "id": "q2112$192A48A1-870D-4FCE-B7B2-28195D9A82E3",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P473": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P473",
-                    "datavalue": {
-                        "value": "05203",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "q2112$62B0FEBB-1124-47BF-B52B-778C3AFE0ABF",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P473",
-                    "datavalue": {
-                        "value": "05208",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "q2112$FDF5BCE4-6CC7-4365-B27F-9B98420AC15C",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P473",
-                    "datavalue": {
-                        "value": "05202",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "q2112$2E3234D1-C698-4E93-B338-571753A3E151",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P473",
-                    "datavalue": {
-                        "value": "05205",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "q2112$2841ACAE-BAE2-4AF9-9A9C-360455F5ED6E",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P473",
-                    "datavalue": {
-                        "value": "05206",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "q2112$BE09D022-2E4B-4ABE-947F-CF379F1A2F78",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P473",
-                    "datavalue": {
-                        "value": "05209",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "q2112$D123A730-9BCE-4F29-B4CB-602C8A26AE55",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P473",
-                    "datavalue": {
-                        "value": "0521",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "q2112$3695888F-A19F-4A4F-BA2C-1B7B4B1F6C54",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P18": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P18",
-                    "datavalue": {
-                        "value": "Bielefeld City.jpg",
-                        "type": "string"
-                    },
-                    "datatype": "commonsMedia"
-                },
-                "type": "statement",
-                "id": "q2112$E4C01D75-5256-450B-B255-10BD78E4746E",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P281": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33501",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "q2112$9C2D6441-F91A-477B-8AE7-DFB232219F18",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33602",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$fe83124c-4b80-80d6-ccd9-670d15f0052b",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33604",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$be921563-4efd-2b77-1867-eb8a226791a0",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33605",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$40b184bb-4289-8c09-57a9-0723ab302de5",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33607",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$883f6cb6-4de5-3180-017c-cd36f3fb3e5b",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33609",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$4895ee99-436a-745a-9bed-75cedcaf2008",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33611",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$bd2e5b5b-46bf-f029-c701-fc9a5e256692",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33613",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$333fddfc-4fd7-a2ea-1d0f-53cba00ab6df",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33615",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$46b25c5b-4f26-c201-1603-b28406e4af58",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33617",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$709ee031-447e-ac19-fce8-7540a74d1e4f",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33619",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$4a8eab7a-4334-422c-1d34-f4e7f8c2f09d",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P281",
-                    "datavalue": {
-                        "value": "33647",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$b59b26a8-4ce9-1dcf-0f1f-a8f3c80bc694",
-                "rank": "normal"
-            }
-        ],
-        "P421": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P421",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 6655,
-                            "id": "Q6655"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "q2112$F7D9FDE7-9A76-4BBA-B767-57DD5CC05BC0",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "50f57a3dbac4708ce4ae4a827c0afac7fcdb4a5c",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 11920,
-                                            "id": "Q11920"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P94": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P94",
-                    "datavalue": {
-                        "value": "DEU Bielefeld COA.svg",
-                        "type": "string"
-                    },
-                    "datatype": "commonsMedia"
-                },
-                "type": "statement",
-                "id": "q2112$c08c9fd9-4c37-00c0-1ea5-836cdd666e99",
-                "rank": "normal"
-            }
-        ],
-        "P625": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P625",
-                    "datavalue": {
-                        "value": {
-                            "latitude": 52.016666666667,
-                            "longitude": 8.5166666666667,
-                            "altitude": null,
-                            "precision": 0.016666666666667,
-                            "globe": "http://www.wikidata.org/entity/Q2"
-                        },
-                        "type": "globecoordinate"
-                    },
-                    "datatype": "globe-coordinate"
-                },
-                "type": "statement",
-                "id": "q2112$29E4B481-C941-4D57-A2DF-D43D585EBCD7",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "d6e3ab4045fb3f3feea77895bc6b27e663fc878a",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 206855,
-                                            "id": "Q206855"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P910": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P910",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 8299342,
-                            "id": "Q8299342"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$2C8D2E62-4948-414E-92B4-24BF8A9927E2",
-                "rank": "normal"
-            }
-        ],
-        "P998": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P998",
-                    "datavalue": {
-                        "value": "Regional/Europe/Germany/States/North_Rhine-Westphalia/Localities/Bielefeld/",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$309762A1-0BCE-403E-A077-EE134205CFA3",
-                "rank": "normal"
-            }
-        ],
-        "P935": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P935",
-                    "datavalue": {
-                        "value": "Bielefeld",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$E8FEB008-5717-4596-983A-BBB40B6B3641",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "2f183743080f8e1970847d13a04fde9a796f1476",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 191168,
-                                            "id": "Q191168"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P982": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P982",
-                    "datavalue": {
-                        "value": "dbdd7aff-9bf5-4084-98c3-722f27d7bb4d",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$3538FAB2-E378-454E-9988-629139322733",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "73057782312f850e2ed69c4c28ad162f57f6d390",
-                        "snaks": {
-                            "P248": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P248",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 14005,
-                                            "id": "Q14005"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P248"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P31": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P31",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 22865,
-                            "id": "Q22865"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$46E8FD92-5274-4DFE-9F2A-2719F1D9CE4C",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P31",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 262166,
-                            "id": "Q262166"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$38134304-E789-4973-A751-3DB7FC5A107A",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P31",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1549591,
-                            "id": "Q1549591"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$cf4a5f75-4245-2131-25ae-690f446eec1b",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P31",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1187811,
-                            "id": "Q1187811"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$25f234bb-47fd-5ab7-93b4-49587bdda6f3",
-                "rank": "normal"
-            }
-        ],
-        "P646": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P646",
-                    "datavalue": {
-                        "value": "/m/018m98",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$F7E6E076-733C-4CE4-A6C6-7AEE8C751407",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "af38848ab5d9d9325cffd93a5ec656cc6ca889ed",
-                        "snaks": {
-                            "P248": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P248",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 15241312,
-                                            "id": "Q15241312"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ],
-                            "P577": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P577",
-                                    "datavalue": {
-                                        "value": {
-                                            "time": "+2013-10-28T00:00:00Z",
-                                            "timezone": 0,
-                                            "before": 0,
-                                            "after": 0,
-                                            "precision": 11,
-                                            "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                        },
-                                        "type": "time"
-                                    },
-                                    "datatype": "time"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P248",
-                            "P577"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P395": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P395",
-                    "datavalue": {
-                        "value": "BI",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$89CF5A79-9B5F-4387-B6C7-E40F35899FFE",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "004ec6fbee857649acdbdbad4f97b2c8571df97b",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 48183,
-                                            "id": "Q48183"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P1464": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1464",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 8046295,
-                            "id": "Q8046295"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$B44FE7D7-943D-4E88-8377-FF26AC3F5387",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "d6e3ab4045fb3f3feea77895bc6b27e663fc878a",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 206855,
-                                            "id": "Q206855"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P1465": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1465",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 15080547,
-                            "id": "Q15080547"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$F9F5D42A-0AFD-48DA-A0B7-E9629955F9C5",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "d6e3ab4045fb3f3feea77895bc6b27e663fc878a",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 206855,
-                                            "id": "Q206855"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P1566": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1566",
-                    "datavalue": {
-                        "value": "2949186",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$D081BAAD-9096-4811-A1DD-B527D2D84EEB",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "d6193e4d78598db1a6aaa453fface1553022f1f2",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 830106,
-                                            "id": "Q830106"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P47": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P47",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 6234,
-                            "id": "Q6234"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$30B0A1FD-0C2F-4FE1-8E7C-FAFD59D3E6C6",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P47",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 6230,
-                            "id": "Q6230"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$1898A933-22B2-4168-9C45-F80167067376",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P47",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 6218,
-                            "id": "Q6218"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$ce588248-4da8-0d2e-9b61-ff15d6a70292",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P47",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 3771,
-                            "id": "Q3771"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$D1F4CE78-475A-44C7-8F75-0B9FCD927AFF",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P47",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 225375,
-                            "id": "Q225375"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$8AA0A799-1ABC-4BDA-BEF6-16A8985A98D9",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P47",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 225432,
-                            "id": "Q225432"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$6B5A58C8-C477-4579-9227-C9D93CB304F1",
-                "rank": "normal"
-            }
-        ],
-        "P1792": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1792",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 6957433,
-                            "id": "Q6957433"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$437E1325-8BB0-4568-B9BA-C7F94200357B",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "d6e3ab4045fb3f3feea77895bc6b27e663fc878a",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 206855,
-                                            "id": "Q206855"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P856": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P856",
-                    "datavalue": {
-                        "value": "http://www.bielefeld.de/",
-                        "type": "string"
-                    },
-                    "datatype": "url"
-                },
-                "type": "statement",
-                "id": "Q2112$3335ab91-46c6-1a2b-1e4c-d3dbf26fbffa",
-                "rank": "normal"
-            }
-        ],
-        "P1842": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1842",
-                    "datavalue": {
-                        "value": "Bielefeld (Nordrhein-Westfalen, Germany)",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$1647C309-5101-44F3-B139-7507EC753D09",
-                "rank": "normal"
-            }
-        ],
-        "P605": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P605",
-                    "datavalue": {
-                        "value": "DEA41",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$65002439-5FBA-4608-83D6-5C783213E20C",
-                "rank": "normal"
-            }
-        ],
-        "P948": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P948",
-                    "datavalue": {
-                        "value": "Bielefeld City.jpg",
-                        "type": "string"
-                    },
-                    "datatype": "commonsMedia"
-                },
-                "type": "statement",
-                "id": "Q2112$b5f9b40e-4e0b-298a-cd71-5636bde79c27",
-                "rank": "normal"
-            }
-        ],
-        "P214": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P214",
-                    "datavalue": {
-                        "value": "312796170",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$ECB9E5BB-B2E1-4E77-8CEE-4E9F4938EB86",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "d6b4bc80e47def2fab91836d81e1db62c640279c",
-                        "snaks": {
-                            "P248": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P248",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 54919,
-                                            "id": "Q54919"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ],
-                            "P813": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P813",
-                                    "datavalue": {
-                                        "value": {
-                                            "time": "+2015-08-02T00:00:00Z",
-                                            "timezone": 0,
-                                            "before": 0,
-                                            "after": 0,
-                                            "precision": 11,
-                                            "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                        },
-                                        "type": "time"
-                                    },
-                                    "datatype": "time"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P248",
-                            "P813"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P268": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P268",
-                    "datavalue": {
-                        "value": "119717772",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$F1ABA1D6-7D7F-470E-89F9-C3D3E664518E",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "c544d671be6fa439d0291a1408f0d8aa3315a3a1",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 20666306,
-                                            "id": "Q20666306"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ],
-                            "P813": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P813",
-                                    "datavalue": {
-                                        "value": {
-                                            "time": "+2015-08-26T00:00:00Z",
-                                            "timezone": 0,
-                                            "before": 0,
-                                            "after": 0,
-                                            "precision": 11,
-                                            "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                        },
-                                        "type": "time"
-                                    },
-                                    "datatype": "time"
-                                }
-                            ],
-                            "P248": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P248",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 20666306,
-                                            "id": "Q20666306"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143",
-                            "P813",
-                            "P248"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P2044": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P2044",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+118",
-                            "unit": "http://www.wikidata.org/entity/Q11573",
-                            "upperBound": "+119",
-                            "lowerBound": "+117"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "id": "Q2112$76c84b7c-48b5-926e-61e2-d67392ffb5cd",
-                "rank": "normal"
-            }
-        ],
-        "P2046": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P2046",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+258.82",
-                            "unit": "http://www.wikidata.org/entity/Q712226",
-                            "upperBound": "+258.83",
-                            "lowerBound": "+258.81"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "id": "Q2112$09b14b95-48fa-51d9-6439-857ef7546d1a",
-                "rank": "normal"
-            }
-        ],
-        "P1082": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+329327",
-                            "unit": "1",
-                            "upperBound": "+329327",
-                            "lowerBound": "+329327"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "6b90c8a291f21f74011a8fcabbe31ce913deee1c",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+2014-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$8fbbff17-4c64-ad1c-101f-abccc532f2dd",
-                "rank": "preferred"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+328864",
-                            "unit": "1",
-                            "upperBound": "+328864",
-                            "lowerBound": "+328864"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "6bb693f1a6d374d92f521c6df054fdc7e2a93851",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+2013-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$b0c923ce-4da2-e5c9-a5e2-c2c4be158368",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+328314",
-                            "unit": "1",
-                            "upperBound": "+328314",
-                            "lowerBound": "+328314"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "024ca32b99e13ae9fc82d7165c2d6dcbfea9ed09",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+2012-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$76a05a89-477c-e32b-c088-668f91fa6c0f",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+327199",
-                            "unit": "1",
-                            "upperBound": "+327199",
-                            "lowerBound": "+327199"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "137aacd8166e34fc57a0c09c6a9ae20f96afdf8f",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+2011-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$c84e2137-4b5a-f3fd-6f17-88202a5b138b",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+323270",
-                            "unit": "1",
-                            "upperBound": "+323270",
-                            "lowerBound": "+323270"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "9bf6eff9234e5e5d644ad57b199210114ca3a2b0",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+2010-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$6791af67-472b-e371-45b7-ec7528cbf716",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+321758",
-                            "unit": "1",
-                            "upperBound": "+321758",
-                            "lowerBound": "+321758"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "043cbc7eb4e8cfd5dac9ba4f372a35284242ce95",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+2000-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$7dd5d4cd-4fa7-2829-6165-86286d350b31",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+319037",
-                            "unit": "1",
-                            "upperBound": "+319037",
-                            "lowerBound": "+319037"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "b51b9a2fc5bfc3e9cb6e37e252e51bc482142420",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1990-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$50b7ef16-49f8-c70b-c355-4ece5058bf0e",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+312708",
-                            "unit": "1",
-                            "upperBound": "+312708",
-                            "lowerBound": "+312708"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "d668834b9f85f1a2c72bf1800d40be85ff6f2df7",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1980-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$c0264e81-4938-6d64-8fb8-ddd17a355d14",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+169134",
-                            "unit": "1",
-                            "upperBound": "+169134",
-                            "lowerBound": "+169134"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "ee88daaca07e19743b1d6da9ef00aa728d9b6165",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1970-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$29d64e00-48d1-2f93-0b5a-7eb5a50d6fad",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1082",
-                    "datavalue": {
-                        "value": {
-                            "amount": "+175076",
-                            "unit": "1",
-                            "upperBound": "+175076",
-                            "lowerBound": "+175076"
-                        },
-                        "type": "quantity"
-                    },
-                    "datatype": "quantity"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P585": [
-                        {
-                            "snaktype": "value",
-                            "property": "P585",
-                            "hash": "d1d611e16b0eb25faf417a374d9de011c22fddaf",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1960-12-31T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P585"
-                ],
-                "id": "Q2112$854da7fe-453f-8699-e2af-f84a698c5528",
-                "rank": "normal"
-            }
-        ],
-        "P6": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P6",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 2097128,
-                            "id": "Q2097128"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "545dc8f19c7e21edb1fd20bbf9daf70d81d8303e",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+2009-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580"
-                ],
-                "id": "Q2112$f25d52b8-4612-03b0-9eed-5f0dd3ab2f0a",
-                "rank": "preferred"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P6",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1278930,
-                            "id": "Q1278930"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "4c04eeada53556b405850e9276a18d78afc8f558",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1999-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ],
-                    "P582": [
-                        {
-                            "snaktype": "value",
-                            "property": "P582",
-                            "hash": "4285c17a766b63b830000b204f7f841aa032689f",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+2009-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580",
-                    "P582"
-                ],
-                "id": "Q2112$b2262ba4-4caa-c41e-0a85-6d53a039e03b",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P6",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 534246,
-                            "id": "Q534246"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "8c1dc5a440bda69b46026b583ee2b23c9c13b5f5",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1994-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ],
-                    "P582": [
-                        {
-                            "snaktype": "value",
-                            "property": "P582",
-                            "hash": "a2967c05930fd98d4539e870543129b413b52115",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1999-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580",
-                    "P582"
-                ],
-                "id": "Q2112$c42f0323-432e-29d9-05bf-11677780f69f",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P6",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1460066,
-                            "id": "Q1460066"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "23b241fcb473b8c928dd8c31584636134b9f79a9",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1975-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ],
-                    "P582": [
-                        {
-                            "snaktype": "value",
-                            "property": "P582",
-                            "hash": "e10922697cf15eaa232bcea931bbe2e811579a11",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1989-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580",
-                    "P582"
-                ],
-                "id": "Q2112$106d7788-4a77-4cd6-2f47-a10c09b3c110",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P6",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1278930,
-                            "id": "Q1278930"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "qualifiers": {
-                    "P580": [
-                        {
-                            "snaktype": "value",
-                            "property": "P580",
-                            "hash": "31c9d9462d158515616a61cb81e1cbeaa051c063",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1989-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ],
-                    "P582": [
-                        {
-                            "snaktype": "value",
-                            "property": "P582",
-                            "hash": "9528424273e0bb949e3228a74670a8473bc85d22",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+1994-00-00T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 9,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                },
-                                "type": "time"
-                            },
-                            "datatype": "time"
-                        }
-                    ]
-                },
-                "qualifiers-order": [
-                    "P580",
-                    "P582"
-                ],
-                "id": "Q2112$2838f3af-4add-6607-ba80-3bc3ba3d789c",
-                "rank": "normal"
-            }
-        ],
-        "P706": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P706",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 677337,
-                            "id": "Q677337"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$65b5efac-47fd-bb47-4257-302d24d130e9",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P706",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 109773,
-                            "id": "Q109773"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$a495c830-45d7-4736-095d-58907fc3aa9a",
-                "rank": "normal"
-            }
-        ],
-        "P150": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 630083,
-                            "id": "Q630083"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$60299de1-45b4-459f-9ec9-d6eb41fc1489",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 884493,
-                            "id": "Q884493"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$cb9a303c-4f57-ef50-1045-3523e6c5fb2a",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1490832,
-                            "id": "Q1490832"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$57e2ac7d-4041-272c-38a9-aa839f17e700",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1593495,
-                            "id": "Q1593495"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$e3272425-4ac3-9d07-9ace-af56615373bd",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1715175,
-                            "id": "Q1715175"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$a71db9b5-4918-bb21-c15d-3be2044c73cc",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 857314,
-                            "id": "Q857314"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$4b1c7510-4330-3844-c5d6-fe6c1d975cb8",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 2235530,
-                            "id": "Q2235530"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$63529cc8-409d-6eb2-d69e-d9318f17cdf6",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1457938,
-                            "id": "Q1457938"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$e1afa8d7-4aa8-30cf-7e50-0badc7c9cd5d",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 2271193,
-                            "id": "Q2271193"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$ed392035-44d2-530a-bf93-d4a87d621bb5",
-                "rank": "normal"
-            },
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P150",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 2348419,
-                            "id": "Q2348419"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$2b21719e-49b2-59e8-10d0-6736045788f2",
-                "rank": "normal"
-            }
-        ],
-        "P1249": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1249",
-                    "datavalue": {
-                        "value": {
-                            "time": "+1214-00-00T00:00:00Z",
-                            "timezone": 0,
-                            "before": 0,
-                            "after": 0,
-                            "precision": 9,
-                            "calendarmodel": "http://www.wikidata.org/entity/Q1985786"
-                        },
-                        "type": "time"
-                    },
-                    "datatype": "time"
-                },
-                "type": "statement",
-                "id": "Q2112$c901acf3-4744-0dd1-7e43-88ec0a71145e",
-                "rank": "normal"
-            }
-        ],
-        "P1456": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1456",
-                    "datavalue": {
-                        "value": {
-                            "entity-type": "item",
-                            "numeric-id": 1831146,
-                            "id": "Q1831146"
-                        },
-                        "type": "wikibase-entityid"
-                    },
-                    "datatype": "wikibase-item"
-                },
-                "type": "statement",
-                "id": "Q2112$577603c9-43f2-0a94-dcd0-d8b87c55df65",
-                "rank": "normal"
-            }
-        ],
-        "P443": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P443",
-                    "datavalue": {
-                        "value": "De-Bielefeld.ogg",
-                        "type": "string"
-                    },
-                    "datatype": "commonsMedia"
-                },
-                "type": "statement",
-                "id": "Q2112$9415F03B-BA96-494E-8E69-15C77568AC48",
-                "rank": "normal"
-            }
-        ],
-        "P1997": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1997",
-                    "datavalue": {
-                        "value": "110710585624249",
-                        "type": "string"
-                    },
-                    "datatype": "string"
-                },
-                "type": "statement",
-                "id": "Q2112$6ce3508f-4873-b666-ae04-6bcf648bfc63",
-                "rank": "normal"
-            }
-        ],
-        "P949": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P949",
-                    "datavalue": {
-                        "value": "000977673",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$1DE0DD3F-B074-40A6-A43C-599656BF879F",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "d6381f29ef78a9f82f1330cd0db04b690f69c6d9",
-                        "snaks": {
-                            "P143": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P143",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 54919,
-                                            "id": "Q54919"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ],
-                            "P813": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P813",
-                                    "datavalue": {
-                                        "value": {
-                                            "time": "+2016-04-01T00:00:00Z",
-                                            "timezone": 0,
-                                            "before": 0,
-                                            "after": 0,
-                                            "precision": 11,
-                                            "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-                                        },
-                                        "type": "time"
-                                    },
-                                    "datatype": "time"
-                                }
-                            ],
-                            "P854": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P854",
-                                    "datavalue": {
-                                        "value": "http://www.viaf.org/viaf/312796170/",
-                                        "type": "string"
-                                    },
-                                    "datatype": "url"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P143",
-                            "P813",
-                            "P854"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P1281": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P1281",
-                    "datavalue": {
-                        "value": "638806",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$2B741744-55F6-44FD-ADC7-F3BFFDE27B64",
-                "rank": "normal",
-                "references": [
-                    {
-                        "hash": "c9d156f833b29ee7067d82a3f68c584438c73796",
-                        "snaks": {
-                            "P248": [
-                                {
-                                    "snaktype": "value",
-                                    "property": "P248",
-                                    "datavalue": {
-                                        "value": {
-                                            "entity-type": "item",
-                                            "numeric-id": 24010939,
-                                            "id": "Q24010939"
-                                        },
-                                        "type": "wikibase-entityid"
-                                    },
-                                    "datatype": "wikibase-item"
-                                }
-                            ]
-                        },
-                        "snaks-order": [
-                            "P248"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "P244": [
-            {
-                "mainsnak": {
-                    "snaktype": "value",
-                    "property": "P244",
-                    "datavalue": {
-                        "value": "n79145551",
-                        "type": "string"
-                    },
-                    "datatype": "external-id"
-                },
-                "type": "statement",
-                "id": "Q2112$05001FE4-C232-4653-98A5-75A8C3EFE026",
-                "rank": "normal"
-            }
-        ]
+    "en": {
+      "language": "en",
+      "value": "Bielefeld"
     },
-    "sitelinks": {
-        "afwiki": {
-            "site": "afwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "arwiki": {
-            "site": "arwiki",
-            "title": "بيلفلد",
-            "badges": []
-        },
-        "azwiki": {
-            "site": "azwiki",
-            "title": "Bilefeld",
-            "badges": []
-        },
-        "barwiki": {
-            "site": "barwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "be_x_oldwiki": {
-            "site": "be_x_oldwiki",
-            "title": "Білефэльд",
-            "badges": []
-        },
-        "bewiki": {
-            "site": "bewiki",
-            "title": "Горад Білефельд",
-            "badges": []
-        },
-        "bgwiki": {
-            "site": "bgwiki",
-            "title": "Билефелд",
-            "badges": []
-        },
-        "cawiki": {
-            "site": "cawiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "cebwiki": {
-            "site": "cebwiki",
-            "title": "Bielefeld (kapital sa munisipyo)",
-            "badges": []
-        },
-        "commonswiki": {
-            "site": "commonswiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "cswiki": {
-            "site": "cswiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "cvwiki": {
-            "site": "cvwiki",
-            "title": "Билефелд",
-            "badges": []
-        },
-        "cywiki": {
-            "site": "cywiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "dawiki": {
-            "site": "dawiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "dewiki": {
-            "site": "dewiki",
-            "title": "Bielefeld",
-            "badges": [
-                "Q17437796"
-            ]
-        },
-        "dewikiquote": {
-            "site": "dewikiquote",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "dewikisource": {
-            "site": "dewikisource",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "dewikivoyage": {
-            "site": "dewikivoyage",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "elwiki": {
-            "site": "elwiki",
-            "title": "Μπίλεφελντ",
-            "badges": []
-        },
-        "enwiki": {
-            "site": "enwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "enwikivoyage": {
-            "site": "enwikivoyage",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "eowiki": {
-            "site": "eowiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "eswiki": {
-            "site": "eswiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "etwiki": {
-            "site": "etwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "euwiki": {
-            "site": "euwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "fawiki": {
-            "site": "fawiki",
-            "title": "بیله‌فلد",
-            "badges": []
-        },
-        "fawikivoyage": {
-            "site": "fawikivoyage",
-            "title": "بیلفلد",
-            "badges": []
-        },
-        "fiwiki": {
-            "site": "fiwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "frrwiki": {
-            "site": "frrwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "frwiki": {
-            "site": "frwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "frwikivoyage": {
-            "site": "frwikivoyage",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "fywiki": {
-            "site": "fywiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "glwiki": {
-            "site": "glwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "gvwiki": {
-            "site": "gvwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "hewiki": {
-            "site": "hewiki",
-            "title": "בילפלד",
-            "badges": []
-        },
-        "hrwiki": {
-            "site": "hrwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "hsbwiki": {
-            "site": "hsbwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "huwiki": {
-            "site": "huwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "hywiki": {
-            "site": "hywiki",
-            "title": "Բիլեֆելդ",
-            "badges": []
-        },
-        "idwiki": {
-            "site": "idwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "iewiki": {
-            "site": "iewiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "iswiki": {
-            "site": "iswiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "itwiki": {
-            "site": "itwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "jawiki": {
-            "site": "jawiki",
-            "title": "ビーレフェルト",
-            "badges": []
-        },
-        "kawiki": {
-            "site": "kawiki",
-            "title": "ბილეფილდი",
-            "badges": []
-        },
-        "kkwiki": {
-            "site": "kkwiki",
-            "title": "Билефельд",
-            "badges": []
-        },
-        "kowiki": {
-            "site": "kowiki",
-            "title": "빌레펠트",
-            "badges": []
-        },
-        "kshwiki": {
-            "site": "kshwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "kuwiki": {
-            "site": "kuwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "kywiki": {
-            "site": "kywiki",
-            "title": "Билефельд",
-            "badges": []
-        },
-        "lawiki": {
-            "site": "lawiki",
-            "title": "Bilivelda",
-            "badges": []
-        },
-        "liwiki": {
-            "site": "liwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "ltwiki": {
-            "site": "ltwiki",
-            "title": "Bylefeldas",
-            "badges": []
-        },
-        "lvwiki": {
-            "site": "lvwiki",
-            "title": "Bīlefelde",
-            "badges": []
-        },
-        "mkwiki": {
-            "site": "mkwiki",
-            "title": "Билефелд",
-            "badges": []
-        },
-        "mnwiki": {
-            "site": "mnwiki",
-            "title": "Билефельд",
-            "badges": []
-        },
-        "mrwiki": {
-            "site": "mrwiki",
-            "title": "बीलेफेल्ड",
-            "badges": []
-        },
-        "ndswiki": {
-            "site": "ndswiki",
-            "title": "Builefeld",
-            "badges": []
-        },
-        "nlwiki": {
-            "site": "nlwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "nnwiki": {
-            "site": "nnwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "nowiki": {
-            "site": "nowiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "ocwiki": {
-            "site": "ocwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "plwiki": {
-            "site": "plwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "plwikivoyage": {
-            "site": "plwikivoyage",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "pnbwiki": {
-            "site": "pnbwiki",
-            "title": "بیلفیلڈ",
-            "badges": []
-        },
-        "ptwiki": {
-            "site": "ptwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "rowiki": {
-            "site": "rowiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "ruwiki": {
-            "site": "ruwiki",
-            "title": "Билефельд",
-            "badges": []
-        },
-        "scowiki": {
-            "site": "scowiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "shwiki": {
-            "site": "shwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "simplewiki": {
-            "site": "simplewiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "skwiki": {
-            "site": "skwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "srwiki": {
-            "site": "srwiki",
-            "title": "Билефелд",
-            "badges": []
-        },
-        "stqwiki": {
-            "site": "stqwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "svwiki": {
-            "site": "svwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "swwiki": {
-            "site": "swwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "szlwiki": {
-            "site": "szlwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "thwiki": {
-            "site": "thwiki",
-            "title": "บีเลอเฟลด์",
-            "badges": []
-        },
-        "trwiki": {
-            "site": "trwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "ttwiki": {
-            "site": "ttwiki",
-            "title": "Билефелд",
-            "badges": []
-        },
-        "ukwiki": {
-            "site": "ukwiki",
-            "title": "Білефельд",
-            "badges": []
-        },
-        "urwiki": {
-            "site": "urwiki",
-            "title": "بیئلفیلڈ",
-            "badges": []
-        },
-        "uzwiki": {
-            "site": "uzwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "viwiki": {
-            "site": "viwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "vowiki": {
-            "site": "vowiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "warwiki": {
-            "site": "warwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "zh_min_nanwiki": {
-            "site": "zh_min_nanwiki",
-            "title": "Bielefeld",
-            "badges": []
-        },
-        "zhwiki": {
-            "site": "zhwiki",
-            "title": "比勒费尔德",
-            "badges": []
-        }
+    "be-tarask": {
+      "language": "be-tarask",
+      "value": "Білефэльд"
+    },
+    "nan": {
+      "language": "nan",
+      "value": "Bielefeld"
+    },
+    "gv": {
+      "language": "gv",
+      "value": "Bielefeld"
+    },
+    "de-ch": {
+      "language": "de-ch",
+      "value": "Bielefeld"
+    },
+    "en-ca": {
+      "language": "en-ca",
+      "value": "Bielefeld"
+    },
+    "en-gb": {
+      "language": "en-gb",
+      "value": "Bielefeld"
+    },
+    "af": {
+      "language": "af",
+      "value": "Bielefeld"
+    },
+    "ar": {
+      "language": "ar",
+      "value": "بيلفلد"
+    },
+    "az": {
+      "language": "az",
+      "value": "Bielefeld"
+    },
+    "be": {
+      "language": "be",
+      "value": "Білефельд"
+    },
+    "bg": {
+      "language": "bg",
+      "value": "Билефелд"
+    },
+    "ca": {
+      "language": "ca",
+      "value": "Bielefeld"
+    },
+    "cs": {
+      "language": "cs",
+      "value": "Bielefeld"
+    },
+    "cv": {
+      "language": "cv",
+      "value": "Билефелд"
+    },
+    "cy": {
+      "language": "cy",
+      "value": "Bielefeld"
+    },
+    "da": {
+      "language": "da",
+      "value": "Bielefeld"
+    },
+    "diq": {
+      "language": "diq",
+      "value": "Bielefeld"
+    },
+    "el": {
+      "language": "el",
+      "value": "Μπίλεφελντ"
+    },
+    "eo": {
+      "language": "eo",
+      "value": "Bielefeld"
+    },
+    "es": {
+      "language": "es",
+      "value": "Bielefeld"
+    },
+    "et": {
+      "language": "et",
+      "value": "Bielefeld"
+    },
+    "eu": {
+      "language": "eu",
+      "value": "Bielefeld"
+    },
+    "fa": {
+      "language": "fa",
+      "value": "بیله‌فلد"
+    },
+    "fi": {
+      "language": "fi",
+      "value": "Bielefeld"
+    },
+    "frr": {
+      "language": "frr",
+      "value": "Bielefeld"
+    },
+    "fy": {
+      "language": "fy",
+      "value": "Bielefeld"
+    },
+    "hr": {
+      "language": "hr",
+      "value": "Bielefeld"
+    },
+    "hu": {
+      "language": "hu",
+      "value": "Bielefeld"
+    },
+    "id": {
+      "language": "id",
+      "value": "Bielefeld"
+    },
+    "is": {
+      "language": "is",
+      "value": "Bielefeld"
+    },
+    "it": {
+      "language": "it",
+      "value": "Bielefeld"
+    },
+    "ja": {
+      "language": "ja",
+      "value": "ビーレフェルト"
+    },
+    "ka": {
+      "language": "ka",
+      "value": "ბილეფილდი"
+    },
+    "kk": {
+      "language": "kk",
+      "value": "Билефельд"
+    },
+    "ko": {
+      "language": "ko",
+      "value": "빌레펠트"
+    },
+    "ksh": {
+      "language": "ksh",
+      "value": "Bielefeld"
+    },
+    "ku": {
+      "language": "ku",
+      "value": "Bielefeld"
+    },
+    "la": {
+      "language": "la",
+      "value": "Bilivelda"
+    },
+    "lt": {
+      "language": "lt",
+      "value": "Bylefeldas"
+    },
+    "lv": {
+      "language": "lv",
+      "value": "Bīlefelde"
+    },
+    "mr": {
+      "language": "mr",
+      "value": "बीलेफेल्ड"
+    },
+    "nds": {
+      "language": "nds",
+      "value": "Builefeld"
+    },
+    "nl": {
+      "language": "nl",
+      "value": "Bielefeld"
+    },
+    "nn": {
+      "language": "nn",
+      "value": "Bielefeld"
+    },
+    "oc": {
+      "language": "oc",
+      "value": "Bielefeld"
+    },
+    "pl": {
+      "language": "pl",
+      "value": "Bielefeld"
+    },
+    "pnb": {
+      "language": "pnb",
+      "value": "بیلفیلڈ"
+    },
+    "pt": {
+      "language": "pt",
+      "value": "Bielefeld"
+    },
+    "pt-br": {
+      "language": "pt-br",
+      "value": "Bielefeld"
+    },
+    "ro": {
+      "language": "ro",
+      "value": "Bielefeld"
+    },
+    "sk": {
+      "language": "sk",
+      "value": "Bielefeld"
+    },
+    "sr": {
+      "language": "sr",
+      "value": "Билефелд"
+    },
+    "sv": {
+      "language": "sv",
+      "value": "Bielefeld"
+    },
+    "sw": {
+      "language": "sw",
+      "value": "Bielefeld"
+    },
+    "tr": {
+      "language": "tr",
+      "value": "Bielefeld"
+    },
+    "uk": {
+      "language": "uk",
+      "value": "Білефельд"
+    },
+    "uz": {
+      "language": "uz",
+      "value": "Bielefeld"
+    },
+    "vi": {
+      "language": "vi",
+      "value": "Bielefeld"
+    },
+    "vo": {
+      "language": "vo",
+      "value": "Bielefeld"
+    },
+    "war": {
+      "language": "war",
+      "value": "Bielefeld"
+    },
+    "zh": {
+      "language": "zh",
+      "value": "比勒费尔德"
+    },
+    "nb": {
+      "language": "nb",
+      "value": "Bielefeld"
+    },
+    "gl": {
+      "language": "gl",
+      "value": "Bielefeld"
+    },
+    "stq": {
+      "language": "stq",
+      "value": "Bielefeld"
+    },
+    "he": {
+      "language": "he",
+      "value": "בילפלד"
+    },
+    "bar": {
+      "language": "bar",
+      "value": "Bielefeld"
+    },
+    "sh": {
+      "language": "sh",
+      "value": "Bielefeld"
+    },
+    "sco": {
+      "language": "sco",
+      "value": "Bielefeld"
+    },
+    "hy": {
+      "language": "hy",
+      "value": "Բիլեֆելդ"
+    },
+    "mn": {
+      "language": "mn",
+      "value": "Билефельд"
+    },
+    "mk": {
+      "language": "mk",
+      "value": "Билефелд"
+    },
+    "an": {
+      "language": "an",
+      "value": "Bielefeld"
+    },
+    "ast": {
+      "language": "ast",
+      "value": "Bielefeld"
+    },
+    "br": {
+      "language": "br",
+      "value": "Bielefeld"
+    },
+    "co": {
+      "language": "co",
+      "value": "Bielefeld"
+    },
+    "de-at": {
+      "language": "de-at",
+      "value": "Bielefeld"
+    },
+    "frp": {
+      "language": "frp",
+      "value": "Bielefeld"
+    },
+    "fur": {
+      "language": "fur",
+      "value": "Bielefeld"
+    },
+    "ga": {
+      "language": "ga",
+      "value": "Bielefeld"
+    },
+    "gd": {
+      "language": "gd",
+      "value": "Bielefeld"
+    },
+    "gsw": {
+      "language": "gsw",
+      "value": "Bielefeld"
+    },
+    "ia": {
+      "language": "ia",
+      "value": "Bielefeld"
+    },
+    "ie": {
+      "language": "ie",
+      "value": "Bielefeld"
+    },
+    "io": {
+      "language": "io",
+      "value": "Bielefeld"
+    },
+    "kg": {
+      "language": "kg",
+      "value": "Bielefeld"
+    },
+    "lb": {
+      "language": "lb",
+      "value": "Bielefeld"
+    },
+    "li": {
+      "language": "li",
+      "value": "Bielefeld"
+    },
+    "lij": {
+      "language": "lij",
+      "value": "Bielefeld"
+    },
+    "mg": {
+      "language": "mg",
+      "value": "Bielefeld"
+    },
+    "min": {
+      "language": "min",
+      "value": "Bielefeld"
+    },
+    "ms": {
+      "language": "ms",
+      "value": "Bielefeld"
+    },
+    "nap": {
+      "language": "nap",
+      "value": "Bielefeld"
+    },
+    "nds-nl": {
+      "language": "nds-nl",
+      "value": "Bielefeld"
+    },
+    "nrm": {
+      "language": "nrm",
+      "value": "Bielefeld"
+    },
+    "pcd": {
+      "language": "pcd",
+      "value": "Bielefeld"
+    },
+    "pms": {
+      "language": "pms",
+      "value": "Bielefeld"
+    },
+    "rm": {
+      "language": "rm",
+      "value": "Bielefeld"
+    },
+    "sc": {
+      "language": "sc",
+      "value": "Bielefeld"
+    },
+    "scn": {
+      "language": "scn",
+      "value": "Bielefeld"
+    },
+    "sl": {
+      "language": "sl",
+      "value": "Bielefeld"
+    },
+    "sr-el": {
+      "language": "sr-el",
+      "value": "Bielefeld"
+    },
+    "vec": {
+      "language": "vec",
+      "value": "Bielefeld"
+    },
+    "vls": {
+      "language": "vls",
+      "value": "Bielefeld"
+    },
+    "wa": {
+      "language": "wa",
+      "value": "Bielefeld"
+    },
+    "wo": {
+      "language": "wo",
+      "value": "Bielefeld"
+    },
+    "zu": {
+      "language": "zu",
+      "value": "Bielefeld"
+    },
+    "ur": {
+      "language": "ur",
+      "value": "بیئلفیلڈ"
+    },
+    "szl": {
+      "language": "szl",
+      "value": "Bielefeld"
+    },
+    "th": {
+      "language": "th",
+      "value": "บีเลอเฟ็ลท์"
+    },
+    "hsb": {
+      "language": "hsb",
+      "value": "Bielefeld"
+    },
+    "ceb": {
+      "language": "ceb",
+      "value": "Bielefeld (kapital sa munisipyo)"
+    },
+    "ky": {
+      "language": "ky",
+      "value": "Билефельд"
+    },
+    "tt": {
+      "language": "tt",
+      "value": "Билефелд"
+    },
+    "yue": {
+      "language": "yue",
+      "value": "比勒費爾德"
+    },
+    "azb": {
+      "language": "azb",
+      "value": "بیله‌فلد"
+    },
+    "hi": {
+      "language": "hi",
+      "value": "बीएलफेल्ड"
+    },
+    "ta": {
+      "language": "ta",
+      "value": "பிஏலேபில்ட்"
+    },
+    "te": {
+      "language": "te",
+      "value": "బియెలెఫిల్డ్"
+    },
+    "bn": {
+      "language": "bn",
+      "value": "বীলেফেল্ড"
+    },
+    "si": {
+      "language": "si",
+      "value": "බීල්ෆෙල්ඩ්"
+    },
+    "gu": {
+      "language": "gu",
+      "value": "બીલેફેલ્ડ"
+    },
+    "kn": {
+      "language": "kn",
+      "value": "ಬೈಲ್ಫೆಲ್ಡ್"
+    },
+    "qu": {
+      "language": "qu",
+      "value": "Bielefeld"
+    },
+    "sq": {
+      "language": "sq",
+      "value": "Bielefeld"
+    },
+    "zh-hant": {
+      "language": "zh-hant",
+      "value": "比勒費爾德"
+    },
+    "ba": {
+      "language": "ba",
+      "value": "Билефельд"
+    },
+    "wuu": {
+      "language": "wuu",
+      "value": "比勒费尔德"
+    },
+    "arz": {
+      "language": "arz",
+      "value": "بيليفيلد"
+    },
+    "ce": {
+      "language": "ce",
+      "value": "Билефельд"
+    },
+    "os": {
+      "language": "os",
+      "value": "Билефельд"
+    },
+    "ckb": {
+      "language": "ckb",
+      "value": "بیلفێلد"
+    },
+    "lld": {
+      "language": "lld",
+      "value": "Bielefeld"
     }
+  },
+  "descriptions": {
+    "de": {
+      "language": "de",
+      "value": "Großstadt in Nordrhein-Westfalen, Deutschland"
+    },
+    "en": {
+      "language": "en",
+      "value": "city in Germany"
+    },
+    "es": {
+      "language": "es",
+      "value": "ciudad independiente alemana en Renania del Norte-Westfalia"
+    },
+    "it": {
+      "language": "it",
+      "value": "città extracircondariale tedesca"
+    },
+    "fr": {
+      "language": "fr",
+      "value": "commune allemande"
+    },
+    "ru": {
+      "language": "ru",
+      "value": "город в Германии"
+    },
+    "el": {
+      "language": "el",
+      "value": "πόλη της Γερμανίας, στην Βόρεια Ρηνανία-Βεστφαλία"
+    },
+    "ne": {
+      "language": "ne",
+      "value": "जर्मनीको सहर"
+    },
+    "nl": {
+      "language": "nl",
+      "value": "gemeente in de Duitse deelstaat Noordrijn-Westfalen"
+    },
+    "he": {
+      "language": "he",
+      "value": "עיר בגרמניה"
+    },
+    "ja": {
+      "language": "ja",
+      "value": "ドイツの都市"
+    },
+    "eo": {
+      "language": "eo",
+      "value": "urbo en Nordrejn-Vestfalio, Germanio"
+    },
+    "sq": {
+      "language": "sq",
+      "value": "qytet në Gjermani"
+    },
+    "hsb": {
+      "language": "hsb",
+      "value": "wulkoměsto w Němskej"
+    },
+    "br": {
+      "language": "br",
+      "value": "kêr alaman"
+    },
+    "zh-hant": {
+      "language": "zh-hant",
+      "value": "德國的城市"
+    },
+    "sl": {
+      "language": "sl",
+      "value": "mesto v Nemčiji"
+    },
+    "la": {
+      "language": "la",
+      "value": "urbs Germaniae"
+    },
+    "be": {
+      "language": "be",
+      "value": "горад у Германіі"
+    },
+    "sv": {
+      "language": "sv",
+      "value": "stad i Nordrhein-Westfalen, Tyskland"
+    },
+    "ar": {
+      "language": "ar",
+      "value": "بلدية في ألمانيا"
+    },
+    "ko": {
+      "language": "ko",
+      "value": "독일 노르트라인베스트팔렌주의 도시"
+    },
+    "zh": {
+      "language": "zh",
+      "value": "德国北莱茵-威斯特法伦州城市"
+    },
+    "lld": {
+      "language": "lld",
+      "value": "zità de la Germania"
+    },
+    "bar": {
+      "language": "bar",
+      "value": "kroasfreie Stod in Deitschland"
+    },
+    "ku": {
+      "language": "ku",
+      "value": "Bajarekî Almanyayê"
+    },
+    "hu": {
+      "language": "hu",
+      "value": "város Németországban"
+    }
+  },
+  "aliases": {
+    "de": [
+      {
+        "language": "de",
+        "value": "Leineweberstadt"
+      },
+      {
+        "language": "de",
+        "value": "Builefeld"
+      },
+      {
+        "language": "de",
+        "value": "Beilefeld"
+      },
+      {
+        "language": "de",
+        "value": "Builefeild"
+      }
+    ],
+    "la": [
+      {
+        "language": "la",
+        "value": "Bilefeldia"
+      }
+    ]
+  },
+  "claims": {
+    "P190": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P190",
+          "hash": "ed13de38867f2c2e8505bb6f9bdd6efe57c6f973",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 207614,
+              "id": "Q207614"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$71781c61-47f7-d370-893c-11f7efe421c8",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P190",
+          "hash": "4f28b4f8554dd314136faf3e35dd9e4e4b10cb51",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 474605,
+              "id": "Q474605"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "a5e0dc0fab1c88e0702eab5557dfec4f8ab8a289",
+              "datavalue": {
+                "value": {
+                  "time": "+1953-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$fa2b9dbe-44c4-e3aa-b1b7-6725768477cf",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "2c1691eaf561a9d7dd6279d62dd1aec8f6434971",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "45c1eadbe361b015db3aa6e83c6c4416f95b6f93",
+                  "datavalue": {
+                    "value": "http://www.rochdale.gov.uk/leisure-and-culture/Pages/20-things-to-know.aspx",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P190",
+          "hash": "ea98f93299289e04a35c00e710c87d512dd437f3",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 990109,
+              "id": "Q990109"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "d630c2c0fcdb2ce4bb70f47b9c52a36855e36bbf",
+              "datavalue": {
+                "value": {
+                  "time": "+1958-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$36372432-48e6-04d2-094b-520cb640f72f",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P190",
+          "hash": "8c98a5cbc6b475f475764d5610ddc63041db7874",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 17393,
+              "id": "Q17393"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "dd39e8ca5409b8e3603542ffaa56775dedc4ef67",
+              "datavalue": {
+                "value": {
+                  "time": "+1973-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$70276a6c-40fe-b35f-f82c-fd93b04c7259",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P190",
+          "hash": "af868a887ed66f866f2dbff734f46ee654492e27",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 167749,
+              "id": "Q167749"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "505ebcd27965193bd5ebf108bb75f8d687e50360",
+              "datavalue": {
+                "value": {
+                  "time": "+1980-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$f77ab273-41c8-96b5-08c1-93af88903cd4",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P190",
+          "hash": "54eb57e91a1d190f05c904ee025e824ef0437c7d",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 2235,
+              "id": "Q2235"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "cb8638f8586a74f9f8254deab9fdde682330a924",
+              "datavalue": {
+                "value": {
+                  "time": "+1987-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$545b65a1-440c-ac9b-2594-8f76c1ffda94",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P190",
+          "hash": "6e1d093345d7cba721a66796495ca26f399f165a",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 598,
+              "id": "Q598"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "807228be43ecce85eae04af992ca74ee377fd749",
+              "datavalue": {
+                "value": {
+                  "time": "+1991-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$8dccc42e-4ede-9f17-8ef5-aee79c88aad3",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P190",
+          "hash": "8144f858ddd59cecd8a349d6734855101fafae08",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1007634,
+              "id": "Q1007634"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "7494268e84b12fc8d9ec79761a1ca187a721adc6",
+              "datavalue": {
+                "value": {
+                  "time": "+1995-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$500e8510-4d28-e8b4-c9b2-53f109218646",
+        "rank": "normal"
+      }
+    ],
+    "P1036": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1036",
+          "hash": "7205fc31aa78266ba6ccee266e80bf0fdd102b29",
+          "datavalue": {
+            "value": "2--435655",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$524f4b4b-46b5-d59c-520b-5eba915a2383",
+        "rank": "normal"
+      }
+    ],
+    "P17": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P17",
+          "hash": "ef7247b704f4ec0a7df39e83306bb388fea17d5f",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 183,
+              "id": "Q183"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "13eff71ba054ad192e12acddfd4ee6725bc28ba9",
+              "datavalue": {
+                "value": {
+                  "time": "+1990-10-03T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "q2112$15E24192-DD4A-47AC-AE3C-31475E98D6B0",
+        "rank": "preferred",
+        "references": [
+          {
+            "hash": "5dabc71043098dc2d1bd6d0b16ce571646b41735",
+            "snaks": {
+              "P5573": [
+                {
+                  "snaktype": "value",
+                  "property": "P5573",
+                  "hash": "c80e039f693f60d12f4fca573946a28ebfb10dd8",
+                  "datavalue": {
+                    "value": "382",
+                    "type": "string"
+                  },
+                  "datatype": "external-id"
+                }
+              ],
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "c619cc6e0e5fe3733a8c4a47939343e5970e0e9d",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 265049,
+                      "id": "Q265049"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "0c8bd92e73708301fbdef488186bd3197b7c3d1c",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2018-08-06T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P5573",
+              "P248",
+              "P813"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P17",
+          "hash": "5b925ba516864377a76a45a5078658f219efc784",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1206012,
+              "id": "Q1206012"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "dd4bac3f0b2163892a60bf02a5c7675704e7f8e0",
+              "datavalue": {
+                "value": {
+                  "time": "+1871-01-18T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P582": [
+            {
+              "snaktype": "value",
+              "property": "P582",
+              "hash": "f12c4bd330e3d7844483eb77ad3977825524c505",
+              "datavalue": {
+                "value": {
+                  "time": "+1949-05-23T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580",
+          "P582"
+        ],
+        "id": "Q2112$13873259-4a84-48e4-583c-edf09a7f301d",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "3593f5f4f686ca7481c8189b51a02610d6abfc52",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "b135f4d2670fa89dc8131c78e0fa9549e89d1a10",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 43458971,
+                      "id": "Q43458971"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P17",
+          "hash": "3912570fabcfa6f9f41e1c53907ee233225c7211",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 713750,
+              "id": "Q713750"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "2ed93c5224a3e784bd15d1eb7c47b4e8ad916a12",
+              "datavalue": {
+                "value": {
+                  "time": "+1949-05-23T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P582": [
+            {
+              "snaktype": "value",
+              "property": "P582",
+              "hash": "57c79b0a475f1529c43a42ad1c80dea59b72bc1a",
+              "datavalue": {
+                "value": {
+                  "time": "+1990-10-02T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580",
+          "P582"
+        ],
+        "id": "Q2112$c024817d-4a24-cf60-0655-2ff4fe15630e",
+        "rank": "normal"
+      }
+    ],
+    "P131": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P131",
+          "hash": "ceda3d1993c959023bfc9f7c3668e5cd1c4772bb",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 7923,
+              "id": "Q7923"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "q2112$AFF3F61B-C161-4593-983D-EDB164FF7093",
+        "rank": "normal"
+      }
+    ],
+    "P227": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P227",
+          "hash": "fca0d613c9e5af91f4a074fb3f44b41ec3eea7bf",
+          "datavalue": {
+            "value": "4006510-8",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "q2112$F84F5E68-5E71-4070-80FB-8C981C01F92D",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "9a24f7c0208b05d6be97077d855671d1dfdbc0dd",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "d38375ffe6fe142663ff55cd783aa4df4301d83d",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 48183,
+                      "id": "Q48183"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P439": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P439",
+          "hash": "3809e7eab05a916fcc49ed819c65d0fa2fe0d598",
+          "datavalue": {
+            "value": "05711000",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "q2112$01477795-1D7B-4551-8022-7DFCBFCCF472",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "fa278ebfc458360e5aed63d5058cca83c46134f1",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "e4f6d9441d0600513c4533c672b5ab472dc73694",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 328,
+                      "id": "Q328"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P373": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P373",
+          "hash": "ab2ffe97e66d878dc09ed15a287e1a1d662b7f54",
+          "datavalue": {
+            "value": "Bielefeld",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "q2112$A30D86DE-3888-47EC-A5E9-1FE72DEC6D66",
+        "rank": "normal"
+      }
+    ],
+    "P242": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P242",
+          "hash": "e7a6cd061d488a970c38de3c14420e8d4c58e29f",
+          "datavalue": {
+            "value": "North rhine w BI.svg",
+            "type": "string"
+          },
+          "datatype": "commonsMedia"
+        },
+        "type": "statement",
+        "id": "q2112$192A48A1-870D-4FCE-B7B2-28195D9A82E3",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d5847b9b6032aa8b13dae3c2dfd9ed5d114d21b3",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5a343e7e758a4282a01316d3e959b6e653b767fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 11920,
+                      "id": "Q11920"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P473": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P473",
+          "hash": "8a956c69befec55e41b441d6e36aa63c4e18ad1a",
+          "datavalue": {
+            "value": "05203",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "q2112$62B0FEBB-1124-47BF-B52B-778C3AFE0ABF",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P473",
+          "hash": "84aa518c89d43aab394b81eee28dd9700aa8acc8",
+          "datavalue": {
+            "value": "05208",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "q2112$FDF5BCE4-6CC7-4365-B27F-9B98420AC15C",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d5847b9b6032aa8b13dae3c2dfd9ed5d114d21b3",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5a343e7e758a4282a01316d3e959b6e653b767fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 11920,
+                      "id": "Q11920"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P473",
+          "hash": "646207b888ec82555f5e2749fadecf3caae1e8d2",
+          "datavalue": {
+            "value": "05202",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "q2112$2E3234D1-C698-4E93-B338-571753A3E151",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d5847b9b6032aa8b13dae3c2dfd9ed5d114d21b3",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5a343e7e758a4282a01316d3e959b6e653b767fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 11920,
+                      "id": "Q11920"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P473",
+          "hash": "39795fc327082571bc8daf2bd5de517732058845",
+          "datavalue": {
+            "value": "05205",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "q2112$2841ACAE-BAE2-4AF9-9A9C-360455F5ED6E",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d5847b9b6032aa8b13dae3c2dfd9ed5d114d21b3",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5a343e7e758a4282a01316d3e959b6e653b767fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 11920,
+                      "id": "Q11920"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P473",
+          "hash": "5e9edc5408c86588dd168f66d8d42d0ad3fd53a5",
+          "datavalue": {
+            "value": "05206",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "q2112$BE09D022-2E4B-4ABE-947F-CF379F1A2F78",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d5847b9b6032aa8b13dae3c2dfd9ed5d114d21b3",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5a343e7e758a4282a01316d3e959b6e653b767fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 11920,
+                      "id": "Q11920"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P473",
+          "hash": "59eea3b0cb569f26d87fa3cc4f394da7069cb06a",
+          "datavalue": {
+            "value": "05209",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "q2112$D123A730-9BCE-4F29-B4CB-602C8A26AE55",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d5847b9b6032aa8b13dae3c2dfd9ed5d114d21b3",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5a343e7e758a4282a01316d3e959b6e653b767fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 11920,
+                      "id": "Q11920"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P473",
+          "hash": "fbccaaba389721ef2f724cd3fbf4b35f1dc35366",
+          "datavalue": {
+            "value": "0521",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "q2112$3695888F-A19F-4A4F-BA2C-1B7B4B1F6C54",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d5847b9b6032aa8b13dae3c2dfd9ed5d114d21b3",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5a343e7e758a4282a01316d3e959b6e653b767fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 11920,
+                      "id": "Q11920"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P281": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "68e4d7f57010af79b446b0f2e8eb6ee6523b50c1",
+          "datavalue": {
+            "value": "33501",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "q2112$9C2D6441-F91A-477B-8AE7-DFB232219F18",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d5847b9b6032aa8b13dae3c2dfd9ed5d114d21b3",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5a343e7e758a4282a01316d3e959b6e653b767fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 11920,
+                      "id": "Q11920"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "78d8b0aa9b540b573e811ad4a986a36f0d5fbfb4",
+          "datavalue": {
+            "value": "33602",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$fe83124c-4b80-80d6-ccd9-670d15f0052b",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "f0dc525077237c90854dbd6bfa81b8edc9795bf1",
+          "datavalue": {
+            "value": "33604",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$be921563-4efd-2b77-1867-eb8a226791a0",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "2fa1819e9d025e52d2e96ad0fbaa51192b833a59",
+          "datavalue": {
+            "value": "33605",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$40b184bb-4289-8c09-57a9-0723ab302de5",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "be93dbb0ff9d0c2cded9c6a9fd495cd35ded58ce",
+          "datavalue": {
+            "value": "33607",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$883f6cb6-4de5-3180-017c-cd36f3fb3e5b",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "d49b06c9f1a6737389daaaf51fe5df8d42ebddba",
+          "datavalue": {
+            "value": "33609",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$4895ee99-436a-745a-9bed-75cedcaf2008",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "2108fcc4bc2cabc03740de723dd6364d8b17635d",
+          "datavalue": {
+            "value": "33611",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$bd2e5b5b-46bf-f029-c701-fc9a5e256692",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "818cf2bcccad3ff0dd873dc711664a55d26504fd",
+          "datavalue": {
+            "value": "33613",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$333fddfc-4fd7-a2ea-1d0f-53cba00ab6df",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "be357196749d57ad2b88c8d22bcb45c3fc190016",
+          "datavalue": {
+            "value": "33615",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$46b25c5b-4f26-c201-1603-b28406e4af58",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "99eb8d409896aab056fcc2fc0c4e9df89b918f63",
+          "datavalue": {
+            "value": "33617",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$709ee031-447e-ac19-fce8-7540a74d1e4f",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "f8defcb2dbea03fe001f4959970a4141ef3e2725",
+          "datavalue": {
+            "value": "33619",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$4a8eab7a-4334-422c-1d34-f4e7f8c2f09d",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P281",
+          "hash": "b94f1dd812436c41e5f7ea20c1660a3954a9f54d",
+          "datavalue": {
+            "value": "33647",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$b59b26a8-4ce9-1dcf-0f1f-a8f3c80bc694",
+        "rank": "normal"
+      }
+    ],
+    "P421": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P421",
+          "hash": "53ab731bb59fd06a123a2d042d206bd52199e918",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 6655,
+              "id": "Q6655"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P1264": [
+            {
+              "snaktype": "value",
+              "property": "P1264",
+              "hash": "5a71e6a321809311ea1a1998db98d29c34b5226d",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 1777301,
+                  "id": "Q1777301"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P1264"
+        ],
+        "id": "q2112$F7D9FDE7-9A76-4BBA-B767-57DD5CC05BC0",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d5847b9b6032aa8b13dae3c2dfd9ed5d114d21b3",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5a343e7e758a4282a01316d3e959b6e653b767fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 11920,
+                      "id": "Q11920"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P421",
+          "hash": "2f5d88b20f122f125387179df70f54990074d5a8",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 6723,
+              "id": "Q6723"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P1264": [
+            {
+              "snaktype": "value",
+              "property": "P1264",
+              "hash": "bbce95c43e978fcfb784754a6507030a95cf31f3",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 36669,
+                  "id": "Q36669"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P1264"
+        ],
+        "id": "Q2112$8E84AB8A-DAFA-49A5-8961-E7EC48D3DB3A",
+        "rank": "normal"
+      }
+    ],
+    "P94": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P94",
+          "hash": "82c8bae72be1ed3f5887026012db6ec76fba01b9",
+          "datavalue": {
+            "value": "DEU Bielefeld COA.svg",
+            "type": "string"
+          },
+          "datatype": "commonsMedia"
+        },
+        "type": "statement",
+        "id": "q2112$c08c9fd9-4c37-00c0-1ea5-836cdd666e99",
+        "rank": "normal"
+      }
+    ],
+    "P625": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P625",
+          "hash": "167d81702b79caaf8961160099ab03cfbd8c0337",
+          "datavalue": {
+            "value": {
+              "latitude": 52.016666666667,
+              "longitude": 8.5333333333333,
+              "altitude": null,
+              "precision": 0.016666666666667,
+              "globe": "http://www.wikidata.org/entity/Q2"
+            },
+            "type": "globecoordinate"
+          },
+          "datatype": "globe-coordinate"
+        },
+        "type": "statement",
+        "id": "q2112$29E4B481-C941-4D57-A2DF-D43D585EBCD7",
+        "rank": "normal"
+      }
+    ],
+    "P910": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P910",
+          "hash": "34f96d47126aefb6a8a4b1f2d03e4d0acbe5879a",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 8299342,
+              "id": "Q8299342"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$2C8D2E62-4948-414E-92B4-24BF8A9927E2",
+        "rank": "normal"
+      }
+    ],
+    "P998": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P998",
+          "hash": "7c900c8adbc111d2408ad5ef7aad69ff11c65295",
+          "datavalue": {
+            "value": "Regional/Europe/Germany/States/North_Rhine-Westphalia/Localities/Bielefeld/",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$309762A1-0BCE-403E-A077-EE134205CFA3",
+        "rank": "normal"
+      }
+    ],
+    "P935": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P935",
+          "hash": "92da1e5b713e9f93644e9059cb6e4ef49a3bdba7",
+          "datavalue": {
+            "value": "Bielefeld",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$E8FEB008-5717-4596-983A-BBB40B6B3641",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "3bf39867b037e8e494a8389ae8a03bad6825a7fc",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5946b91c53409c48f5f1fb0319ed41fc67a764da",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 191168,
+                      "id": "Q191168"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P982": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P982",
+          "hash": "33c3aff80c177d1dc48371a86fe3af941728cec6",
+          "datavalue": {
+            "value": "dbdd7aff-9bf5-4084-98c3-722f27d7bb4d",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$3538FAB2-E378-454E-9988-629139322733",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "706208b3024200fd0a39ad499808dd0d98d74065",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "623cc8f0e2f65afe4d66b91962d354a2f3aa9a27",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 14005,
+                      "id": "Q14005"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      }
+    ],
+    "P31": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P31",
+          "hash": "1af62c39c83b583e317a43f838058583f06f38aa",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1549591,
+              "id": "Q1549591"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$cf4a5f75-4245-2131-25ae-690f446eec1b",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P31",
+          "hash": "bdb6f126705767b3cdc4f25f8e25e957d48273e8",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1187811,
+              "id": "Q1187811"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$25f234bb-47fd-5ab7-93b4-49587bdda6f3",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P31",
+          "hash": "3cc6f14378f29d82a2d01b7b084ee308ef0ff76a",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 42744322,
+              "id": "Q42744322"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$f27b0ef7-4912-7113-4ad7-702b0bfb5874",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P31",
+          "hash": "ab570b13939bb6a8e83d0224e925290bac31095b",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1964689,
+              "id": "Q1964689"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P3680": [
+            {
+              "snaktype": "value",
+              "property": "P3680",
+              "hash": "e667d8a0e14a6fd67a6538f493e68edd8d21ddb8",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 703899,
+                  "id": "Q703899"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ],
+          "P2241": [
+            {
+              "snaktype": "value",
+              "property": "P2241",
+              "hash": "3b8f8092e729f1e7122ad00e62f10c860e2c6312",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 128758,
+                  "id": "Q128758"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P3680",
+          "P2241"
+        ],
+        "id": "Q2112$2dd0e8df-425a-6940-e4b0-a46ae4960a48",
+        "rank": "deprecated"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P31",
+          "hash": "bb7a0f3695a2b9c2665aa8464888fc7920b7cca6",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 707813,
+              "id": "Q707813"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$BB9C6302-5567-4037-94A1-5E66B2F2A201",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "9a24f7c0208b05d6be97077d855671d1dfdbc0dd",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "d38375ffe6fe142663ff55cd783aa4df4301d83d",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 48183,
+                      "id": "Q48183"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P31",
+          "hash": "d47c0d6e860aa068e7e8bac188bcfd3204049fca",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 85635630,
+              "id": "Q85635630"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$652E7CD7-BC6B-4EE7-9848-29888EE9023D",
+        "rank": "normal"
+      }
+    ],
+    "P646": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P646",
+          "hash": "bd51e928744d31dfb58aedc371000bd05a73d7a0",
+          "datavalue": {
+            "value": "/m/018m98",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$F7E6E076-733C-4CE4-A6C6-7AEE8C751407",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "2b00cb481cddcac7623114367489b5c194901c4a",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "a94b740202b097dd33355e0e6c00e54b9395e5e0",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 15241312,
+                      "id": "Q15241312"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P577": [
+                {
+                  "snaktype": "value",
+                  "property": "P577",
+                  "hash": "fde79ecb015112d2f29229ccc1ec514ed3e71fa2",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2013-10-28T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248",
+              "P577"
+            ]
+          }
+        ]
+      }
+    ],
+    "P395": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P395",
+          "hash": "f1abc57026c3709eab76828168db5ae8c03f6bc3",
+          "datavalue": {
+            "value": "BI",
+            "type": "string"
+          },
+          "datatype": "string"
+        },
+        "type": "statement",
+        "id": "Q2112$89CF5A79-9B5F-4387-B6C7-E40F35899FFE",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "9a24f7c0208b05d6be97077d855671d1dfdbc0dd",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "d38375ffe6fe142663ff55cd783aa4df4301d83d",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 48183,
+                      "id": "Q48183"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P1464": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1464",
+          "hash": "850522eb10358762af138a8920bca1215340e489",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 8046295,
+              "id": "Q8046295"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$B44FE7D7-943D-4E88-8377-FF26AC3F5387",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "288ab581e7d2d02995a26dfa8b091d96e78457fc",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "6a164248fc96bfa583bbb495cb63ae6401ec203c",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 206855,
+                      "id": "Q206855"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P1465": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1465",
+          "hash": "3ffdbe42e299ef1be80f61ab36a58275ef7eff74",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 15080547,
+              "id": "Q15080547"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$F9F5D42A-0AFD-48DA-A0B7-E9629955F9C5",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "288ab581e7d2d02995a26dfa8b091d96e78457fc",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "6a164248fc96bfa583bbb495cb63ae6401ec203c",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 206855,
+                      "id": "Q206855"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P1566": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1566",
+          "hash": "b4bff12134df4be132433ecb74bd9fd7afa19fd6",
+          "datavalue": {
+            "value": "3221125",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$D081BAAD-9096-4811-A1DD-B527D2D84EEB",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "88694a0f4d1486770c269f7db16a1982f74da69d",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "1b3ef912a2bd61e18dd43abd184337eb010b2e96",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 830106,
+                      "id": "Q830106"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      }
+    ],
+    "P47": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "ce6f7de134dcd441b4b66da341e14a4c60d75b27",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 6234,
+              "id": "Q6234"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$30B0A1FD-0C2F-4FE1-8E7C-FAFD59D3E6C6",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "2c91ac94755a57df75441f5599bec97d582f28a8",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 6230,
+              "id": "Q6230"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$1898A933-22B2-4168-9C45-F80167067376",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "8c26ac1bdef4b338e465dc3c5a553a502b4f7b8f",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 6218,
+              "id": "Q6218"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$ce588248-4da8-0d2e-9b61-ff15d6a70292",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "79a9a7c0a1ce36449478f445dba8ff0263b82d49",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 3771,
+              "id": "Q3771"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$D1F4CE78-475A-44C7-8F75-0B9FCD927AFF",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "efc4c5d15368ca0849165b1d689a4df39ee9725c",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 225375,
+              "id": "Q225375"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$8AA0A799-1ABC-4BDA-BEF6-16A8985A98D9",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "689f8b74caaa68e07a51b718eef055d23cf46fa1",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 225432,
+              "id": "Q225432"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$6B5A58C8-C477-4579-9227-C9D93CB304F1",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "cf1551920850ab1aee6fe02d0247a84dfa158757",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 242757,
+              "id": "Q242757"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$6619d5e4-4db3-d0ab-fc30-a456b9db3429",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "209685671ed45050d22d47e0b78b69b3ebe7ba04",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 242385,
+              "id": "Q242385"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$8fd6a541-405a-2c8a-9c4d-ec929596cae1",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "45bf801906f2cb7f16384b1ca1d68ecf475180e8",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 4108,
+              "id": "Q4108"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$7cb0d646-47c9-88db-f2cf-23255334a99e",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "d953d37192249ff4f9c98d5a198048b4c96a08d4",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 3971,
+              "id": "Q3971"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$025bb123-46fd-8689-f1b9-c66fabe061bb",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "96c6e1c6d043faf472e5384a9391958eb2c587be",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 53901,
+              "id": "Q53901"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$172f431e-4bdd-fcaa-d43a-b31d38db9d57",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "90e71e69ee34b8b3da23dbe46cbb9bb83afbde05",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 53904,
+              "id": "Q53904"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$a7fbb0da-4922-9156-61ed-08fa37214034",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "732bf7ee1bf68ade9cdd5314e9c63fd2b91e65dc",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 32750,
+              "id": "Q32750"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$69af88eb-46a6-2670-5395-d7631821be34",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P47",
+          "hash": "864d481ae493800e04ad28495549dd6381cc7a89",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 225002,
+              "id": "Q225002"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$35bedb81-4237-70be-feb6-85b4ab58f025",
+        "rank": "normal"
+      }
+    ],
+    "P1792": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1792",
+          "hash": "578f3dade0e27ea645b960fb50ae212a7cab994b",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 6957433,
+              "id": "Q6957433"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$437E1325-8BB0-4568-B9BA-C7F94200357B",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "288ab581e7d2d02995a26dfa8b091d96e78457fc",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "6a164248fc96bfa583bbb495cb63ae6401ec203c",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 206855,
+                      "id": "Q206855"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P856": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P856",
+          "hash": "80381e98b8141af9b4e6333c88c24f74c5f484b5",
+          "datavalue": {
+            "value": "https://www.bielefeld.de/",
+            "type": "string"
+          },
+          "datatype": "url"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P407": [
+            {
+              "snaktype": "value",
+              "property": "P407",
+              "hash": "46bfd327b830f66f7061ea92d1be430c135fa91f",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 188,
+                  "id": "Q188"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ],
+          "P813": [
+            {
+              "snaktype": "value",
+              "property": "P813",
+              "hash": "0a4658c4948753a9397bfc6e63b1db12a7b6ef33",
+              "datavalue": {
+                "value": {
+                  "time": "+2017-05-18T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P407",
+          "P813"
+        ],
+        "id": "Q2112$3335ab91-46c6-1a2b-1e4c-d3dbf26fbffa",
+        "rank": "normal"
+      }
+    ],
+    "P1842": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1842",
+          "hash": "006d7afafdae7c5333d1fa61bc0e1310bcc6483f",
+          "datavalue": {
+            "value": "Bielefeld (Nordrhein-Westfalen, Germany)",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$1647C309-5101-44F3-B139-7507EC753D09",
+        "rank": "normal"
+      }
+    ],
+    "P605": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P605",
+          "hash": "29debb985aacf9dd6e4000bf8472c7e65e9f53f7",
+          "datavalue": {
+            "value": "DEA41",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$65002439-5FBA-4608-83D6-5C783213E20C",
+        "rank": "normal"
+      }
+    ],
+    "P948": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P948",
+          "hash": "7a9890bdf199b6474a7d467921a7d0cfda85fd64",
+          "datavalue": {
+            "value": "Bielefeld WV banner.jpg",
+            "type": "string"
+          },
+          "datatype": "commonsMedia"
+        },
+        "type": "statement",
+        "id": "Q2112$b5f9b40e-4e0b-298a-cd71-5636bde79c27",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "e71a7903858496c67eea189a7084d5559f788edb",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "5d3b16d350189b0a81818758208505444c86c127",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 565,
+                      "id": "Q565"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P214": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P214",
+          "hash": "8e6a011a885047c383589450fc51243d7faa8a37",
+          "datavalue": {
+            "value": "312796170",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$ECB9E5BB-B2E1-4E77-8CEE-4E9F4938EB86",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "94cd09bdd3373d7b8eb4e3cc26e524afe7466ff7",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "6b7d4330c4aac4caec4ede9de0311ce273f88ecd",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 54919,
+                      "id": "Q54919"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "bf4494cf3e2345d75aa355a5847a72d38ca6c55d",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2015-08-02T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248",
+              "P813"
+            ]
+          }
+        ]
+      }
+    ],
+    "P2044": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P2044",
+          "hash": "03ce7737a9859a77d23f604ec3185f0c44a3f293",
+          "datavalue": {
+            "value": {
+              "amount": "+118",
+              "unit": "http://www.wikidata.org/entity/Q11573",
+              "upperBound": "+119",
+              "lowerBound": "+117"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "id": "Q2112$76c84b7c-48b5-926e-61e2-d67392ffb5cd",
+        "rank": "normal"
+      }
+    ],
+    "P2046": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P2046",
+          "hash": "61a5f1314cbf6213ad75cef630d5b6a2835f9d90",
+          "datavalue": {
+            "value": {
+              "amount": "+258.82",
+              "unit": "http://www.wikidata.org/entity/Q712226",
+              "upperBound": "+258.83",
+              "lowerBound": "+258.81"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "745b29605c9c7cf8a1060810e30146ddb0260f3e",
+              "datavalue": {
+                "value": {
+                  "time": "+2017-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$09b14b95-48fa-51d9-6439-857ef7546d1a",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "e01b2898f64db40c9073666f5838f842bc376350",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "e6045358cacbb7c1edf78db909812f5211953e86",
+                  "datavalue": {
+                    "value": "https://www.destatis.de/DE/ZahlenFakten/LaenderRegionen/Regionales/Gemeindeverzeichnis/Administrativ/Archiv/GVAuszugQ/AuszugGV4QAktuell.html",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P1476": [
+                {
+                  "snaktype": "value",
+                  "property": "P1476",
+                  "hash": "336a0894b79760511be6df3ca74afd27e338ad1f",
+                  "datavalue": {
+                    "value": {
+                      "text": "Alle politisch selbständigen Gemeinden mit ausgewählten Merkmalen am 31.12.2018 (4. Quartal)",
+                      "language": "de"
+                    },
+                    "type": "monolingualtext"
+                  },
+                  "datatype": "monolingualtext"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "214d6abff03532386de80a727956428c0f93e51d",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2019-03-10T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ],
+              "P123": [
+                {
+                  "snaktype": "value",
+                  "property": "P123",
+                  "hash": "006e4a871c1adf076c6c611dea42d0700ab67532",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 764739,
+                      "id": "Q764739"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P1065": [
+                {
+                  "snaktype": "value",
+                  "property": "P1065",
+                  "hash": "9fa075ef58fb07978ae4cc6d475b256f92560d48",
+                  "datavalue": {
+                    "value": "https://web.archive.org/web/20190310200237/https://www.destatis.de/DE/ZahlenFakten/LaenderRegionen/Regionales/Gemeindeverzeichnis/Administrativ/Archiv/GVAuszugQ/AuszugGV4QAktuell.xlsx?__blob=publicationFile",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P2960": [
+                {
+                  "snaktype": "value",
+                  "property": "P2960",
+                  "hash": "393a5e68f8a17d4b0971b4f81930a8712d6434b1",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2019-03-10T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854",
+              "P1476",
+              "P813",
+              "P123",
+              "P1065",
+              "P2960"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P2046",
+          "hash": "65c0b0a70fcb0c26094c59c4bc428bf0f6cace9b",
+          "datavalue": {
+            "value": {
+              "amount": "+258.82",
+              "unit": "http://www.wikidata.org/entity/Q712226"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "f4e1bbc6e9b3a72c2e1fd3e6061f4c7e7f5acad9",
+              "datavalue": {
+                "value": {
+                  "time": "+2016-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$2b09b4a2-4b50-bf41-b440-8f3d2a8212ca",
+        "rank": "preferred",
+        "references": [
+          {
+            "hash": "6a9584393b4f3bd86e108c46356afc26d8d0fba7",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "6e85cfb0fd4b45ee5ead4091a64e7f934af3f8d4",
+                  "datavalue": {
+                    "value": "https://www.destatis.de/DE/ZahlenFakten/LaenderRegionen/Regionales/Gemeindeverzeichnis/Administrativ/Aktuell/05Staedte.html",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854"
+            ]
+          }
+        ]
+      }
+    ],
+    "P1082": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "a7bb5993f6a03dc442d224d35cf8841f982cb585",
+          "datavalue": {
+            "value": {
+              "amount": "+328864",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "1568911fac5843944dbf80f171ebea12f51090e5",
+              "datavalue": {
+                "value": {
+                  "time": "+2013-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$b0c923ce-4da2-e5c9-a5e2-c2c4be158368",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "ff26729c5f8703a0d808a50e840eb7dcb800e914",
+          "datavalue": {
+            "value": {
+              "amount": "+328314",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "d071256bb4b9260491239bfad2cc561ad8bf870c",
+              "datavalue": {
+                "value": {
+                  "time": "+2012-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$76a05a89-477c-e32b-c088-668f91fa6c0f",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "0dd37471f72b6f9136b490be061324b3473a1195",
+          "datavalue": {
+            "value": {
+              "amount": "+327199",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "73d6a2774ad3dff7dc2d301d2e1193b716d635fb",
+              "datavalue": {
+                "value": {
+                  "time": "+2011-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$c84e2137-4b5a-f3fd-6f17-88202a5b138b",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "da59baa2684fe00c745ac015ad1651f7f837d409",
+          "datavalue": {
+            "value": {
+              "amount": "+323270",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "d079326e3ce3c56de50885e3305a2d316cc91861",
+              "datavalue": {
+                "value": {
+                  "time": "+2010-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$6791af67-472b-e371-45b7-ec7528cbf716",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "b32ee9c6e1a24d6a53c4010f7cc9cdc2db9359a8",
+          "datavalue": {
+            "value": {
+              "amount": "+321758",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "2abb6a19fe3eb0b1aeeb3564ed0e868376f04473",
+              "datavalue": {
+                "value": {
+                  "time": "+2000-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$7dd5d4cd-4fa7-2829-6165-86286d350b31",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "dfa6b69a0f64cabbc6c2f450425b4061f0c5ddd9",
+          "datavalue": {
+            "value": {
+              "amount": "+319037",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "62a8da970c5a0271b1d724dc95a3a9814de621af",
+              "datavalue": {
+                "value": {
+                  "time": "+1990-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$50b7ef16-49f8-c70b-c355-4ece5058bf0e",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "b12a18a6a0b02c23a233e9f91487982b501c2ef7",
+          "datavalue": {
+            "value": {
+              "amount": "+312708",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "4f01944ee7ebf6af821d64a877d7d8319dc3331c",
+              "datavalue": {
+                "value": {
+                  "time": "+1980-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$c0264e81-4938-6d64-8fb8-ddd17a355d14",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "be5b43316db78b07ee0abf67a34fee0f5dd77242",
+          "datavalue": {
+            "value": {
+              "amount": "+169134",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "93f8805564afa292df16f67cdbf0c3c0f0304199",
+              "datavalue": {
+                "value": {
+                  "time": "+1970-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$29d64e00-48d1-2f93-0b5a-7eb5a50d6fad",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "16893e22eb8c88f768e2c11a7519a3fb70383ea1",
+          "datavalue": {
+            "value": {
+              "amount": "+175076",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "049152bb3040ad4309b2cb474a10f16947abd8f6",
+              "datavalue": {
+                "value": {
+                  "time": "+1960-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$854da7fe-453f-8699-e2af-f84a698c5528",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "e3d9acc8bad0023d6f749c240400e8b8bfe51d65",
+          "datavalue": {
+            "value": {
+              "amount": "+333451",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "50e3b9c4ecacaca2ba92107b638691cbfbc9121b",
+              "datavalue": {
+                "value": {
+                  "time": "+2016-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$63238aab-43c8-8bec-2f18-5bc7700a68b9",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "6a9584393b4f3bd86e108c46356afc26d8d0fba7",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "6e85cfb0fd4b45ee5ead4091a64e7f934af3f8d4",
+                  "datavalue": {
+                    "value": "https://www.destatis.de/DE/ZahlenFakten/LaenderRegionen/Regionales/Gemeindeverzeichnis/Administrativ/Aktuell/05Staedte.html",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "b467a0f3c72b77b8007b3c66c007a9e08da25168",
+          "datavalue": {
+            "value": {
+              "amount": "+332552",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "745b29605c9c7cf8a1060810e30146ddb0260f3e",
+              "datavalue": {
+                "value": {
+                  "time": "+2017-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$2568FE76-5EAA-4E81-9E3F-83B2653AD929",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "e01b2898f64db40c9073666f5838f842bc376350",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "e6045358cacbb7c1edf78db909812f5211953e86",
+                  "datavalue": {
+                    "value": "https://www.destatis.de/DE/ZahlenFakten/LaenderRegionen/Regionales/Gemeindeverzeichnis/Administrativ/Archiv/GVAuszugQ/AuszugGV4QAktuell.html",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P1476": [
+                {
+                  "snaktype": "value",
+                  "property": "P1476",
+                  "hash": "336a0894b79760511be6df3ca74afd27e338ad1f",
+                  "datavalue": {
+                    "value": {
+                      "text": "Alle politisch selbständigen Gemeinden mit ausgewählten Merkmalen am 31.12.2018 (4. Quartal)",
+                      "language": "de"
+                    },
+                    "type": "monolingualtext"
+                  },
+                  "datatype": "monolingualtext"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "214d6abff03532386de80a727956428c0f93e51d",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2019-03-10T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ],
+              "P123": [
+                {
+                  "snaktype": "value",
+                  "property": "P123",
+                  "hash": "006e4a871c1adf076c6c611dea42d0700ab67532",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 764739,
+                      "id": "Q764739"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P1065": [
+                {
+                  "snaktype": "value",
+                  "property": "P1065",
+                  "hash": "9fa075ef58fb07978ae4cc6d475b256f92560d48",
+                  "datavalue": {
+                    "value": "https://web.archive.org/web/20190310200237/https://www.destatis.de/DE/ZahlenFakten/LaenderRegionen/Regionales/Gemeindeverzeichnis/Administrativ/Archiv/GVAuszugQ/AuszugGV4QAktuell.xlsx?__blob=publicationFile",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P2960": [
+                {
+                  "snaktype": "value",
+                  "property": "P2960",
+                  "hash": "393a5e68f8a17d4b0971b4f81930a8712d6434b1",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2019-03-10T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854",
+              "P1476",
+              "P813",
+              "P123",
+              "P1065",
+              "P2960"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "c4960b8d42147e1b646a752b5f11c03e111390da",
+          "datavalue": {
+            "value": {
+              "amount": "+316058",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "6366a6eb3b6a32302183fb03e38db4d430e9651b",
+              "datavalue": {
+                "value": {
+                  "time": "+1975-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$94A0C68D-EFE7-4C63-BE38-ADF637847709",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "e507d92cb36bc526d032c1df98d5130ff0cacbd2",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "54870a4b16d25e68b63fae3fa4ff37106cac65ee",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 63812020,
+                      "id": "Q63812020"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "4ec118fd53c7e8000838d891685fcd3a8e5ec666",
+          "datavalue": {
+            "value": {
+              "amount": "+333786",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "a293e6ab3db9a2edccdc16c5fa14947bb9217c2a",
+              "datavalue": {
+                "value": {
+                  "time": "+2018-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$55d77c29-49cd-6bad-09c0-ccfee9d4db58",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "4b208575a06fe6e5de9c2a1622012c80f26d159d",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "95a98b082bb2c699f3a7e342d5b6bba1ee337fb8",
+                  "datavalue": {
+                    "value": "https://www.landesdatenbank.nrw.de",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "4ec118fd53c7e8000838d891685fcd3a8e5ec666",
+          "datavalue": {
+            "value": {
+              "amount": "+333786",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "62557a8db62df6f70c440636cdc0d484087c0e70",
+              "datavalue": {
+                "value": {
+                  "time": "+2019-09-30T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P459": [
+            {
+              "snaktype": "value",
+              "property": "P459",
+              "hash": "9a17db6b8b930e6ccfe5013df9d6840428dc679d",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 52679562,
+                  "id": "Q52679562"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585",
+          "P459"
+        ],
+        "id": "Q2112$510C2464-041B-4AA7-BFB0-8F11C0894946",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "01e3c17fd2d73cd4a8921f55d726180eb3d81ffd",
+            "snaks": {
+              "P123": [
+                {
+                  "snaktype": "value",
+                  "property": "P123",
+                  "hash": "006e4a871c1adf076c6c611dea42d0700ab67532",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 764739,
+                      "id": "Q764739"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "408cff8d1a926f7486c60258dd10aefc475eb2cc",
+                  "datavalue": {
+                    "value": "https://www.statistikportal.de/de/produkte/gemeindeverzeichnis",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "337dffc6bbc1faae0597dc43794096c378318ac6",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2020-03-02T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P123",
+              "P854",
+              "P813"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "b233ddc993c165733e78909eb62a8f593a517af8",
+          "datavalue": {
+            "value": {
+              "amount": "+339842",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "8809d0bfc6d96a7916c93c009bb688d4e2876724",
+              "datavalue": {
+                "value": {
+                  "time": "+2019-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P459": [
+            {
+              "snaktype": "value",
+              "property": "P459",
+              "hash": "9a17db6b8b930e6ccfe5013df9d6840428dc679d",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 52679562,
+                  "id": "Q52679562"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585",
+          "P459"
+        ],
+        "id": "Q2112$510909b2-4ae4-cef7-f802-65578626b0ac",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "484df7d55ab32665f14acbefba94059dc27d8701",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "534993008ed2c24c08c2f16ef2bbc09a321ece52",
+                  "datavalue": {
+                    "value": "https://www.bielefeld.de/de/rv/ds_stadtverwaltung/presse/stas/ak/",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "ee6cbe3340d809d85ccdf456db2aba4f5cd83077",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2020-06-28T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854",
+              "P813"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "58bd2c07dc36ca45553fd4424f186dc786ba1bb0",
+          "datavalue": {
+            "value": {
+              "amount": "+333509",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "426b2cbd07318b722a9fe7c7076cdfb1fc29991b",
+              "datavalue": {
+                "value": {
+                  "time": "+2021-09-30T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P459": [
+            {
+              "snaktype": "value",
+              "property": "P459",
+              "hash": "9a17db6b8b930e6ccfe5013df9d6840428dc679d",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 52679562,
+                  "id": "Q52679562"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585",
+          "P459"
+        ],
+        "id": "Q2112$e5dfc1ee-4359-7992-3d84-90ababee9d92",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "dfbd482b73bdd3d9f13c5380ecd6b633dc4464a0",
+            "snaks": {
+              "P123": [
+                {
+                  "snaktype": "value",
+                  "property": "P123",
+                  "hash": "006e4a871c1adf076c6c611dea42d0700ab67532",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 764739,
+                      "id": "Q764739"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "408cff8d1a926f7486c60258dd10aefc475eb2cc",
+                  "datavalue": {
+                    "value": "https://www.statistikportal.de/de/produkte/gemeindeverzeichnis",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "b20b6ddd2023f309fac69bde3cb7d8e7dfcb0ba5",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2022-01-15T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P123",
+              "P854",
+              "P813"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1082",
+          "hash": "5d57b0a8a37c1a11d951669fcfac9b23b314bd56",
+          "datavalue": {
+            "value": {
+              "amount": "+334002",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P1540": [
+            {
+              "snaktype": "value",
+              "property": "P1540",
+              "hash": "c65aca5058cea6e43b99b768c59cff99c815c26d",
+              "datavalue": {
+                "value": {
+                  "amount": "+161237",
+                  "unit": "1"
+                },
+                "type": "quantity"
+              },
+              "datatype": "quantity"
+            }
+          ],
+          "P1539": [
+            {
+              "snaktype": "value",
+              "property": "P1539",
+              "hash": "56f15e890425cd1f37857fb6cd823c2647e10ba1",
+              "datavalue": {
+                "value": {
+                  "amount": "+172765",
+                  "unit": "1"
+                },
+                "type": "quantity"
+              },
+              "datatype": "quantity"
+            }
+          ],
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "33bd9a339157ce7b3d74cb10d73bc23529c9a7f3",
+              "datavalue": {
+                "value": {
+                  "time": "+2021-12-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P459": [
+            {
+              "snaktype": "value",
+              "property": "P459",
+              "hash": "9a17db6b8b930e6ccfe5013df9d6840428dc679d",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 52679562,
+                  "id": "Q52679562"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P1540",
+          "P1539",
+          "P585",
+          "P459"
+        ],
+        "id": "Q2112$91339A3D-144A-49F3-97AB-0F709AE4557A",
+        "rank": "preferred",
+        "references": [
+          {
+            "hash": "7f68dba737140df45dda00c5b75c7a934cc92c24",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "c3b670a3ad03789d8da6136e746e64b1e01031cb",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 116783074,
+                      "id": "Q116783074"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "1f7c787678209c793e427b91c8758e44b29b3250",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2023-02-12T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248",
+              "P813"
+            ]
+          }
+        ]
+      }
+    ],
+    "P6": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P6",
+          "hash": "244ac571914caf28ccf3a341fd1efbe18dedd13b",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 2097128,
+              "id": "Q2097128"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "3fc6ed80ba4863118f4a5be06623083e5226a528",
+              "datavalue": {
+                "value": {
+                  "time": "+2009-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$f25d52b8-4612-03b0-9eed-5f0dd3ab2f0a",
+        "rank": "preferred"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P6",
+          "hash": "d29d0bceaa1290c92934eda3b70362fcf326c5f9",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1278930,
+              "id": "Q1278930"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "1ad6a2e53783f18115d7c4804fcb7a638f669f49",
+              "datavalue": {
+                "value": {
+                  "time": "+1999-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P582": [
+            {
+              "snaktype": "value",
+              "property": "P582",
+              "hash": "f52cccf49da12dade7f191d0b8339eb57ccae88a",
+              "datavalue": {
+                "value": {
+                  "time": "+2009-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580",
+          "P582"
+        ],
+        "id": "Q2112$b2262ba4-4caa-c41e-0a85-6d53a039e03b",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P6",
+          "hash": "5cf70be891926322af6c41a28906f66456a8c211",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 534246,
+              "id": "Q534246"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "7dc2821fe3f7d0644f5ada26fb6c7255ccd0c291",
+              "datavalue": {
+                "value": {
+                  "time": "+1994-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P582": [
+            {
+              "snaktype": "value",
+              "property": "P582",
+              "hash": "bed902185081cc6727fa1f0a6570e225bc5dc7d4",
+              "datavalue": {
+                "value": {
+                  "time": "+1999-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580",
+          "P582"
+        ],
+        "id": "Q2112$c42f0323-432e-29d9-05bf-11677780f69f",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P6",
+          "hash": "14c3a6a3fd4a8ad557ab5e0dd8f8b086d05dc004",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1460066,
+              "id": "Q1460066"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "f7a6fe61ade9471cad1a55305c2d080bc13c680f",
+              "datavalue": {
+                "value": {
+                  "time": "+1975-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P582": [
+            {
+              "snaktype": "value",
+              "property": "P582",
+              "hash": "e2a9e2983e84400425efbf13a1480b9686a21e0e",
+              "datavalue": {
+                "value": {
+                  "time": "+1989-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580",
+          "P582"
+        ],
+        "id": "Q2112$106d7788-4a77-4cd6-2f47-a10c09b3c110",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P6",
+          "hash": "d29d0bceaa1290c92934eda3b70362fcf326c5f9",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1278930,
+              "id": "Q1278930"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "847ac9cf370c98288b78380b0326f288193bdfe9",
+              "datavalue": {
+                "value": {
+                  "time": "+1989-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P582": [
+            {
+              "snaktype": "value",
+              "property": "P582",
+              "hash": "c52610cf2484d0ad6653d33766c3606e3e67ec6f",
+              "datavalue": {
+                "value": {
+                  "time": "+1994-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580",
+          "P582"
+        ],
+        "id": "Q2112$2838f3af-4add-6607-ba80-3bc3ba3d789c",
+        "rank": "normal"
+      }
+    ],
+    "P706": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P706",
+          "hash": "bb64e21cd9bf75b0d3f844f850e76345340dc3c6",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 677337,
+              "id": "Q677337"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$65b5efac-47fd-bb47-4257-302d24d130e9",
+        "rank": "normal"
+      }
+    ],
+    "P150": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "65bf96d405a0f5e9a9ec7cd6d83bc8a1da7ed84b",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 630083,
+              "id": "Q630083"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$60299de1-45b4-459f-9ec9-d6eb41fc1489",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "2750a6e5f8a5a53b8c5dfabcd9f0f9eee0b20a13",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 884493,
+              "id": "Q884493"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$cb9a303c-4f57-ef50-1045-3523e6c5fb2a",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "8254407248121ce0fd8bf9c45218b2321da0c942",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1490832,
+              "id": "Q1490832"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$57e2ac7d-4041-272c-38a9-aa839f17e700",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "02dd69030a7afab63cc94e45a7983c3855fed51f",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1593495,
+              "id": "Q1593495"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$e3272425-4ac3-9d07-9ace-af56615373bd",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "997f8b72bae23c905f96ea760f692f59586a91cf",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1715175,
+              "id": "Q1715175"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$a71db9b5-4918-bb21-c15d-3be2044c73cc",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "1e4d4d13dd5efe06536dfdf9b228f90a3062248b",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 857314,
+              "id": "Q857314"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$4b1c7510-4330-3844-c5d6-fe6c1d975cb8",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "41e98db30d48ea23876984805e2b9be3e6da7357",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 2235530,
+              "id": "Q2235530"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$63529cc8-409d-6eb2-d69e-d9318f17cdf6",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "f6c262978b6bd85a25f47850f140553050f76e40",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1457938,
+              "id": "Q1457938"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$e1afa8d7-4aa8-30cf-7e50-0badc7c9cd5d",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "31d8f658010d745eaf5cf1d7390a3824a0e01f18",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 2271193,
+              "id": "Q2271193"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$ed392035-44d2-530a-bf93-d4a87d621bb5",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P150",
+          "hash": "833cec8562a2eb4b4a46c36f13d25f315a88c538",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 2348419,
+              "id": "Q2348419"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$2b21719e-49b2-59e8-10d0-6736045788f2",
+        "rank": "normal"
+      }
+    ],
+    "P1249": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1249",
+          "hash": "eed29beb9e2394ebe587dc9e1ee9bdc69684505b",
+          "datavalue": {
+            "value": {
+              "time": "+1214-00-00T00:00:00Z",
+              "timezone": 0,
+              "before": 0,
+              "after": 0,
+              "precision": 9,
+              "calendarmodel": "http://www.wikidata.org/entity/Q1985786"
+            },
+            "type": "time"
+          },
+          "datatype": "time"
+        },
+        "type": "statement",
+        "id": "Q2112$c901acf3-4744-0dd1-7e43-88ec0a71145e",
+        "rank": "normal"
+      }
+    ],
+    "P1456": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1456",
+          "hash": "573e80abf223511e6381cfc417df1c24ef3fdb23",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1831146,
+              "id": "Q1831146"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$577603c9-43f2-0a94-dcd0-d8b87c55df65",
+        "rank": "normal"
+      }
+    ],
+    "P1997": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1997",
+          "hash": "77dc2bcffbd4518e05b99f9f1df02c1be4591bcc",
+          "datavalue": {
+            "value": "110710585624249",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$6ce3508f-4873-b666-ae04-6bcf648bfc63",
+        "rank": "normal"
+      }
+    ],
+    "P1281": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1281",
+          "hash": "e42b6c7c6effdd60715863bfaf8a7317c5f9d420",
+          "datavalue": {
+            "value": "638806",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$2B741744-55F6-44FD-ADC7-F3BFFDE27B64",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "d4767d15e44afe8795350d71c4aaf13e1067eea5",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "17354015300275daf133e0956af3a9b170765a0f",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 24010939,
+                      "id": "Q24010939"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      }
+    ],
+    "P244": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P244",
+          "hash": "b6a493ae9f49da5fd53f9da17066d95248ab88cf",
+          "datavalue": {
+            "value": "n79145551",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$05001FE4-C232-4653-98A5-75A8C3EFE026",
+        "rank": "normal"
+      }
+    ],
+    "P3222": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P3222",
+          "hash": "8d3ef6f7cbebd8d41834135773d8e4dab2ad94e4",
+          "datavalue": {
+            "value": "bielefeld",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$7E99103A-0893-41B8-9B46-33DB89D26CAB",
+        "rank": "normal"
+      }
+    ],
+    "P2950": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P2950",
+          "hash": "b22b0afb76e2bcb7aa3b9485d0cba194587b7334",
+          "datavalue": {
+            "value": "bielefeld",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$61B2FCAF-48FF-472F-83F1-578643D5E6FD",
+        "rank": "normal"
+      }
+    ],
+    "P3417": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P3417",
+          "hash": "e660269a4771f6135c3099e97adfdbc543d6637a",
+          "datavalue": {
+            "value": "Bielefeld",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$301CF45C-36BE-4D3B-9C37-6A1D8F6238B3",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "3b0a5bb3c1f955edce73740124f7d935698092ad",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "3ac9682e789a3a3791d4fd088b265ea03abef101",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 51711,
+                      "id": "Q51711"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      }
+    ],
+    "P1813": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1813",
+          "hash": "0ff10de578247e37b3813f0ebb44b52a9b0d051f",
+          "datavalue": {
+            "value": {
+              "text": "Bi",
+              "language": "de"
+            },
+            "type": "monolingualtext"
+          },
+          "datatype": "monolingualtext"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P31": [
+            {
+              "snaktype": "value",
+              "property": "P31",
+              "hash": "79ef508913fd30ffb0f22091b9792d4cce9e5b64",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 28758335,
+                  "id": "Q28758335"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P31"
+        ],
+        "id": "Q2112$664BE4FC-3118-4FE2-BC7F-ABEA50C9C1B6",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "200d4df2297fe2e41a09174c0286089529764f2f",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "32f8b0abf75b653d46b1c3771eda6766affc7e05",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 28657655,
+                      "id": "Q28657655"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1813",
+          "hash": "eb241996408681f06f4d2fcee601ab371b2b0f8c",
+          "datavalue": {
+            "value": {
+              "text": "Bet",
+              "language": "de"
+            },
+            "type": "monolingualtext"
+          },
+          "datatype": "monolingualtext"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P31": [
+            {
+              "snaktype": "value",
+              "property": "P31",
+              "hash": "79ef508913fd30ffb0f22091b9792d4cce9e5b64",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 28758335,
+                  "id": "Q28758335"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P31"
+        ],
+        "id": "Q2112$0ACE24AD-1201-4E3E-9E97-4374CB645E59",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "200d4df2297fe2e41a09174c0286089529764f2f",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "32f8b0abf75b653d46b1c3771eda6766affc7e05",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 28657655,
+                      "id": "Q28657655"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      }
+    ],
+    "P485": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P485",
+          "hash": "120b811f66d147123e180329c79c120b0d407f26",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 28719794,
+              "id": "Q28719794"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$3E1EE597-A571-4C52-88E8-1C2AB03137E7",
+        "rank": "normal"
+      }
+    ],
+    "P402": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P402",
+          "hash": "a3ec18472dc59b51d3adcace53762df923a854d8",
+          "datavalue": {
+            "value": "62646",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$7B5F4495-C830-48D1-9062-A044C94E9918",
+        "rank": "normal"
+      }
+    ],
+    "P2326": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P2326",
+          "hash": "83998015de219d7ffc7239dd21af62bbfa980e09",
+          "datavalue": {
+            "value": "115821",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$d186a8f8-429d-6dec-a966-e2da7254c5e7",
+        "rank": "normal"
+      }
+    ],
+    "P571": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P571",
+          "hash": "630a374e42cd1cdabbf2a15d4947f9073c8c02d7",
+          "datavalue": {
+            "value": {
+              "time": "+1214-00-00T00:00:00Z",
+              "timezone": 0,
+              "before": 0,
+              "after": 0,
+              "precision": 9,
+              "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+            },
+            "type": "time"
+          },
+          "datatype": "time"
+        },
+        "type": "statement",
+        "id": "Q2112$7C90D5AB-DCBC-48F4-A58D-570AF0722630",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "ed8bd3f9343e9a35e58b67284f26a67859f1808d",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "07596fc82d3ed4d248b85e5543852cc31e37dc8c",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 199913,
+                      "id": "Q199913"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P440": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P440",
+          "hash": "7ca9a7d03249e765c3e7b9068ee1fb03481ad9b1",
+          "datavalue": {
+            "value": "05711",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$EB05659D-9ED3-49AF-8081-517B771AFC8C",
+        "rank": "normal"
+      }
+    ],
+    "P4552": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P4552",
+          "hash": "90d7fee636074f66dc7eac7f303683dff7563c07",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 109773,
+              "id": "Q109773"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$AFAD9957-CA86-4176-B459-0C015C467DA0",
+        "rank": "normal"
+      }
+    ],
+    "P4613": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P4613",
+          "hash": "d509ca87b7b746ee6a75f8d21540c9d29e7537ae",
+          "datavalue": {
+            "value": "39984",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$066DD99E-B87D-48AE-BBB0-72B768D9A914",
+        "rank": "normal"
+      }
+    ],
+    "P4672": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P4672",
+          "hash": "8d11fecaac562ed2622deb4b5c7dd3b91a936c36",
+          "datavalue": {
+            "value": "ace4d17f-ef2a-4bb5-b036-e93af6c31429",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$33B3EEAD-BFB6-42D4-BEE7-2626DD5F1320",
+        "rank": "normal"
+      }
+    ],
+    "P361": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P361",
+          "hash": "bb7583041fe7cbac2801d0158283569eb5a59673",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 487924,
+              "id": "Q487924"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$048B7705-5717-46AF-A262-1F9D185CBF23",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "9b6033a0a0fc3d0000b1c77fe93c161cbcbad1a6",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "342852c6ea3be834528dad2b0808c542dc83626d",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 19826574,
+                      "id": "Q19826574"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143"
+            ]
+          }
+        ]
+      }
+    ],
+    "P2924": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P2924",
+          "hash": "dc03172decacbda09c1def841b4611cb7a6e288f",
+          "datavalue": {
+            "value": "1866077",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P2241": [
+            {
+              "snaktype": "value",
+              "property": "P2241",
+              "hash": "74bd46d0bbe97d05804856f1f73b6a7480c68cec",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 45403344,
+                  "id": "Q45403344"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P2241"
+        ],
+        "id": "Q2112$6FE32B17-DE69-4797-9B65-0D1A67757B9D",
+        "rank": "deprecated"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P2924",
+          "hash": "efd131b190d8402b0abf34708dbbe6b596b9549e",
+          "datavalue": {
+            "value": "5660672",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P1810": [
+            {
+              "snaktype": "value",
+              "property": "P1810",
+              "hash": "e8f36f40e3553c602c81997cef4f1b0b368f65f4",
+              "datavalue": {
+                "value": "БИЛЕФЕЛЬД",
+                "type": "string"
+              },
+              "datatype": "string"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P1810"
+        ],
+        "id": "Q2112$68BB05DD-CBA7-4DD2-BD7F-7EA27CF52A2E",
+        "rank": "normal"
+      }
+    ],
+    "P463": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P463",
+          "hash": "e2ddee6f42826794049c029df5241aab90d42f1c",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 627637,
+              "id": "Q627637"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "f77e401c3294559f5f96c8fc18f16d1c6aad6e22",
+              "datavalue": {
+                "value": {
+                  "time": "+1998-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$14919E9D-83FA-4AB7-A811-4AD8ABDEDA3E",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "ed017f00ea19909d5eeb397b162e496f332e6673",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "84c1eed68969779fd1fbac79181c7c747f0b2c97",
+                  "datavalue": {
+                    "value": "http://www.agfs-nrw.de/mitglieder/bielefeld.html",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "410ef0c4fc4cb1ed2a6aa2d2785a7ba5a5c0335d",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2018-04-18T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854",
+              "P813"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P463",
+          "hash": "ac81844cee9c713d304bc6d2b13990262f6be290",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1768108,
+              "id": "Q1768108"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "7494268e84b12fc8d9ec79761a1ca187a721adc6",
+              "datavalue": {
+                "value": {
+                  "time": "+1995-00-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 9,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$C32802FD-D60D-45EE-B9E1-1A7C558361A1",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "5ded2ad7cd0df594690bfc9ec2a6dfcfa8e0343e",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "87a8dc136bdbe4ec2df9b9fc989a916753ada296",
+                  "datavalue": {
+                    "value": "http://www.klimabuendnis.org/nc/kommunen/das-netzwerk.html",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P463",
+          "hash": "ad905af4e1ec302cd359f2b3e3923a7896ee93da",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 747279,
+              "id": "Q747279"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P580": [
+            {
+              "snaktype": "value",
+              "property": "P580",
+              "hash": "cbe87c80920150010196f28588dff888b412cc1f",
+              "datavalue": {
+                "value": {
+                  "time": "+1984-09-00T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 10,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P580"
+        ],
+        "id": "Q2112$EB6FE0A1-B1DD-40D5-8329-E9CCE7094031",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "fb1f6d6c181623e4cccb53e4c1776ca87a3bbf28",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "ad6f189d4ff72b653206611bb79fcf45779be7b4",
+                  "datavalue": {
+                    "value": "http://www.mayorsforpeace.org/english/membercity/map/europe.html",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "38d34404a887a57cec7caa569935f1456c28d12e",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2019-07-04T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854",
+              "P813"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P463",
+          "hash": "d783b96a88c21a59c6cc6278926308c39470e527",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 52144567,
+              "id": "Q52144567"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$963BA0CE-72DC-47CF-88D0-EE787F835F3D",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "b5e9f2c14ee0c5ffa9d2c542cc8f5f6246471d91",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "b5b9f11239fe2870def57793c6e7497dea95ed6d",
+                  "datavalue": {
+                    "value": "http://www.staedtetag-nrw.de/mitglieder/",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "734104bfd49df2173d116988f1820060af83da9c",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2020-01-03T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854",
+              "P813"
+            ]
+          }
+        ]
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P463",
+          "hash": "9d948695ec1e67c5685ad75933437b692d0d1629",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 896216,
+              "id": "Q896216"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$D1B7F81C-CB0A-4723-A21B-742BAA8E201D",
+        "rank": "normal"
+      }
+    ],
+    "P1448": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1448",
+          "hash": "cee1af61214f0256cb3f5e3249a031a7c63a32e2",
+          "datavalue": {
+            "value": {
+              "text": "Bielefeld",
+              "language": "de"
+            },
+            "type": "monolingualtext"
+          },
+          "datatype": "monolingualtext"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P443": [
+            {
+              "snaktype": "value",
+              "property": "P443",
+              "hash": "13cd772175d51e802aa4e57e3f856c5edec6dc05",
+              "datavalue": {
+                "value": "De-Bielefeld.ogg",
+                "type": "string"
+              },
+              "datatype": "commonsMedia"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P443"
+        ],
+        "id": "Q2112$5e5bb585-439e-44bd-d6b3-1973f6979abe",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "3593f5f4f686ca7481c8189b51a02610d6abfc52",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "b135f4d2670fa89dc8131c78e0fa9549e89d1a10",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 43458971,
+                      "id": "Q43458971"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      }
+    ],
+    "P1417": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1417",
+          "hash": "e718839c9e9a144fc8b0830aebfe5480a5a1bde7",
+          "datavalue": {
+            "value": "place/Bielefeld",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$44600D43-76A7-42A6-986A-C48CF30ACD2D",
+        "rank": "normal"
+      }
+    ],
+    "P268": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P268",
+          "hash": "4d4bcdb35b2a791d6f3f63d0b3685f86bc66b6c2",
+          "datavalue": {
+            "value": "119717772",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$B8B1C666-8AAA-4340-8DA1-18AB6A0B3296",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "5a858a70d6ac562123c1debf25a5aed93a5c4939",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "def9f19d84b65167a2a17ce38364d264c16127fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 19938912,
+                      "id": "Q19938912"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "97aefaac0484eca89d5fee539362dc40c533824e",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2015-08-26T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248",
+              "P813"
+            ]
+          }
+        ]
+      }
+    ],
+    "P5573": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P5573",
+          "hash": "c80e039f693f60d12f4fca573946a28ebfb10dd8",
+          "datavalue": {
+            "value": "382",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$896312FA-4735-4B79-B269-7A4FC544D52F",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "21494d78c86d729112257391ca4131a84f73b44b",
+            "snaks": {
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "d845f4eb775982fb2055473e0463f4a17a2cfa54",
+                  "datavalue": {
+                    "value": "https://www.archinform.net/service/wd_aiort.php",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "c619cc6e0e5fe3733a8c4a47939343e5970e0e9d",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 265049,
+                      "id": "Q265049"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "83237a37d47a18cacfe2acba0b8c6667601a1f38",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2018-08-05T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P854",
+              "P248",
+              "P813"
+            ]
+          }
+        ]
+      }
+    ],
+    "P949": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P949",
+          "hash": "e989aee147e1883ba606edbdcd96b6d55a5aa20e",
+          "datavalue": {
+            "value": "000977673",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$60CF8FC8-2BBF-4605-9FBB-7D840FA7417D",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "5b730e1b95048dffefd2ce476535959f2a80abfe",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "6b7d4330c4aac4caec4ede9de0311ce273f88ecd",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 54919,
+                      "id": "Q54919"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P214": [
+                {
+                  "snaktype": "value",
+                  "property": "P214",
+                  "hash": "8e6a011a885047c383589450fc51243d7faa8a37",
+                  "datavalue": {
+                    "value": "312796170",
+                    "type": "string"
+                  },
+                  "datatype": "external-id"
+                }
+              ],
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "500dbeecd3d2f80e2510fac5c34105909af8f59b",
+                  "datavalue": {
+                    "value": "http://www.viaf.org/viaf/312796170/",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "d4f3d264b7badd664450b52ec0157875b216257f",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2016-04-01T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248",
+              "P214",
+              "P854",
+              "P813"
+            ]
+          }
+        ]
+      }
+    ],
+    "P18": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P18",
+          "hash": "31b61ca16837dd36a925bc9a121b178f1bd26c39",
+          "datavalue": {
+            "value": "Sparrenburg innovative sights.JPG",
+            "type": "string"
+          },
+          "datatype": "commonsMedia"
+        },
+        "type": "statement",
+        "id": "Q2112$D64974C0-CFCE-4A73-821A-668812A60FF8",
+        "rank": "normal"
+      }
+    ],
+    "P41": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P41",
+          "hash": "e741c768224ccb33115e313a390030dc9d58aecc",
+          "datavalue": {
+            "value": "Hissflagge Bielefeld.svg",
+            "type": "string"
+          },
+          "datatype": "commonsMedia"
+        },
+        "type": "statement",
+        "id": "Q2112$b4861f8b-4c3b-e517-b408-ecfaa6071a4a",
+        "rank": "preferred"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P41",
+          "hash": "ed086453f74b2837318b8604caeb674750840a34",
+          "datavalue": {
+            "value": "Banner Bielefeld.svg",
+            "type": "string"
+          },
+          "datatype": "commonsMedia"
+        },
+        "type": "statement",
+        "id": "Q2112$2d2435cc-4645-79ea-a500-297350149b82",
+        "rank": "normal"
+      }
+    ],
+    "P6573": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P6573",
+          "hash": "653324edb54be7b6f7567637deba5ca593fe6c1e",
+          "datavalue": {
+            "value": "Bielefeld",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$83733DC4-5FA7-47FC-9076-0823FFC52CC5",
+        "rank": "normal"
+      }
+    ],
+    "P6814": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P6814",
+          "hash": "19af2e6adf5b1ee41af37b9cc0d19f8ad8536cef",
+          "datavalue": {
+            "value": "Q2112",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P4900": [
+            {
+              "snaktype": "value",
+              "property": "P4900",
+              "hash": "398b4ac595546c5cfba7431f1fef539ea2fa0ba2",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 7923,
+                  "id": "Q7923"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P4900"
+        ],
+        "id": "Q2112$EE82692B-A6F2-4D87-B2BB-578045386469",
+        "rank": "normal"
+      }
+    ],
+    "P6766": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P6766",
+          "hash": "c9e53efb4b2ff9771616dbbbe3970deec94b9b67",
+          "datavalue": {
+            "value": "101748767",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$92D81FD4-DF01-466E-B25B-73B4B371D099",
+        "rank": "normal"
+      }
+    ],
+    "P1343": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1343",
+          "hash": "4cfd4eb1fe49d401455df557a7d9b1154f22a725",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 3181656,
+              "id": "Q3181656"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P1810": [
+            {
+              "snaktype": "value",
+              "property": "P1810",
+              "hash": "69b96ca789b038aa03653a2ccd39f1353f8f11d8",
+              "datavalue": {
+                "value": "Bielefeld",
+                "type": "string"
+              },
+              "datatype": "string"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P1810"
+        ],
+        "id": "Q2112$8a956736-410d-a0e5-5fa4-3aa3d5c7e13d",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1343",
+          "hash": "18e6d3e5a4b2e8891df3becff7db1570f149a24e",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 20078554,
+              "id": "Q20078554"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P805": [
+            {
+              "snaktype": "value",
+              "property": "P805",
+              "hash": "833c723e8b2ef39fa86a50a3adeb334e7d9af18d",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 43458971,
+                  "id": "Q43458971"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P805"
+        ],
+        "id": "Q2112$6dc4eea6-4c42-7701-e1dd-0f15c3fa4e96",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1343",
+          "hash": "42346dfe9209b7359c1f5db829a368b38d407797",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 19180675,
+              "id": "Q19180675"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P805": [
+            {
+              "snaktype": "value",
+              "property": "P805",
+              "hash": "7ebb1d7a7a07baf0c7ab8011b822bd837ef8521e",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 24754214,
+                  "id": "Q24754214"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P805"
+        ],
+        "id": "Q2112$0878d0e9-4671-3dbc-cb70-e1948525c09d",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1343",
+          "hash": "88389772f86dcd7d415ddd029f601412e5cc894a",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 602358,
+              "id": "Q602358"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P805": [
+            {
+              "snaktype": "value",
+              "property": "P805",
+              "hash": "b8ac02c26549187a4d2e9cb463944b7ae79b2102",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 24347482,
+                  "id": "Q24347482"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P805"
+        ],
+        "id": "Q2112$9764f6c8-4aa2-f233-6871-cfc33eccd109",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1343",
+          "hash": "7d6f86cef085693a10b0e0663a0960f58d0e15e2",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 4173137,
+              "id": "Q4173137"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P805": [
+            {
+              "snaktype": "value",
+              "property": "P805",
+              "hash": "7d516853d7d5d64cbaab059d7a371b01fd43b490",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 24949770,
+                  "id": "Q24949770"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P805"
+        ],
+        "id": "Q2112$febc06ca-4bad-15f7-bac9-4bc224730602",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1343",
+          "hash": "cc623969772776f2a8b109402b0ac5fa5c123233",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 19219752,
+              "id": "Q19219752"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P805": [
+            {
+              "snaktype": "value",
+              "property": "P805",
+              "hash": "be2ba4a797cb1a4f0671b72f76d842ea428e985a",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 112770941,
+                  "id": "Q112770941"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P805"
+        ],
+        "id": "Q2112$A1CC900A-37F6-437D-B0F6-C47FAA147E63",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1343",
+          "hash": "25990c177615dce5c2d71a82c3eb18d7e8c9efea",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 1547546,
+              "id": "Q1547546"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P805": [
+            {
+              "snaktype": "value",
+              "property": "P805",
+              "hash": "e35cd6ea89bf50c95882e1e6225df2fe92079b67",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 113070827,
+                  "id": "Q113070827"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P805"
+        ],
+        "id": "Q2112$A58F7835-BBC8-470D-A207-93D221CE2753",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1343",
+          "hash": "7fbac838e906d01145b6db01408f4a62f02ec36d",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 19230705,
+              "id": "Q19230705"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P805": [
+            {
+              "snaktype": "value",
+              "property": "P805",
+              "hash": "47f68be154c56f7e6e5372c7550930c1d1e2ddcd",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 113083727,
+                  "id": "Q113083727"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P805"
+        ],
+        "id": "Q2112$CB3AEDD0-C0CF-405B-99BC-6D05BEBADC78",
+        "rank": "normal"
+      }
+    ],
+    "P7471": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P7471",
+          "hash": "05b9a9578ce56b98069e9fa38e983f6f51467264",
+          "datavalue": {
+            "value": "98543",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$6688e6b1-4359-b1e8-47fa-5370f1761b47",
+        "rank": "normal"
+      }
+    ],
+    "P7867": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P7867",
+          "hash": "2627ba275f660f32ce9225366a65c95941b95d01",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 84112142,
+              "id": "Q84112142"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$5a81c730-e303-43c3-825c-b3aed89eff3c",
+        "rank": "normal"
+      }
+    ],
+    "P7818": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P7818",
+          "hash": "97bc7c25c548131b086ae659f90d433da5737a18",
+          "datavalue": {
+            "value": "Bielefeld",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$5FEC84AC-4C9B-44FF-9C0B-7A714A1E5D53",
+        "rank": "normal"
+      }
+    ],
+    "P691": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P691",
+          "hash": "23ed8dd0cb867bde5a8cce07aeee08992b9893a8",
+          "datavalue": {
+            "value": "ge293098",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P1810": [
+            {
+              "snaktype": "value",
+              "property": "P1810",
+              "hash": "70d497638b9018edf3f841a1a830a58ab5243772",
+              "datavalue": {
+                "value": "Bielefeld (Německo)",
+                "type": "string"
+              },
+              "datatype": "string"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P1810"
+        ],
+        "id": "Q2112$EC4F5A87-1D2B-4334-9C87-F1D75ABCB195",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "eb5115599e6a93f57647d90eedf5a498d0532466",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "80047f9d5b0d2daf06989e71bd5f4ba15b215fd6",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 13550863,
+                      "id": "Q13550863"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "55192c6e3b71ad8602db9e8f797dad61974080f3",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2020-02-02T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248",
+              "P813"
+            ]
+          }
+        ]
+      }
+    ],
+    "P7859": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P7859",
+          "hash": "5465db2fd21c09d302fe03bafaabf1f49abab329",
+          "datavalue": {
+            "value": "lccn-n79145551",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$DD4477C1-E399-4AD3-88F7-D45FBBD26AB3",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "68c98b170d41a476ca3e75c65342db2c375dbc9e",
+            "snaks": {
+              "P214": [
+                {
+                  "snaktype": "value",
+                  "property": "P214",
+                  "hash": "8e6a011a885047c383589450fc51243d7faa8a37",
+                  "datavalue": {
+                    "value": "312796170",
+                    "type": "string"
+                  },
+                  "datatype": "external-id"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P214"
+            ]
+          }
+        ]
+      }
+    ],
+    "P1539": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1539",
+          "hash": "b1ac1388bf0a927a4e96b4156d64d4905bc777f3",
+          "datavalue": {
+            "value": {
+              "amount": "+172708",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "5a3f2a7491006129e04514010a00e7810907eb5a",
+              "datavalue": {
+                "value": {
+                  "time": "+2019-10-31T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585"
+        ],
+        "id": "Q2112$1D2D1262-BD58-4A53-8F7D-FA42923A0572",
+        "rank": "normal"
+      },
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1539",
+          "hash": "d0ea6f461c0e85a49915d2775215bbb5a2583a4b",
+          "datavalue": {
+            "value": {
+              "amount": "+172707",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "426b2cbd07318b722a9fe7c7076cdfb1fc29991b",
+              "datavalue": {
+                "value": {
+                  "time": "+2021-09-30T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P459": [
+            {
+              "snaktype": "value",
+              "property": "P459",
+              "hash": "9a17db6b8b930e6ccfe5013df9d6840428dc679d",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 52679562,
+                  "id": "Q52679562"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585",
+          "P459"
+        ],
+        "id": "Q2112$7704960f-40e3-01c9-3d2e-43598189a7ba",
+        "rank": "preferred",
+        "references": [
+          {
+            "hash": "dfbd482b73bdd3d9f13c5380ecd6b633dc4464a0",
+            "snaks": {
+              "P123": [
+                {
+                  "snaktype": "value",
+                  "property": "P123",
+                  "hash": "006e4a871c1adf076c6c611dea42d0700ab67532",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 764739,
+                      "id": "Q764739"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "408cff8d1a926f7486c60258dd10aefc475eb2cc",
+                  "datavalue": {
+                    "value": "https://www.statistikportal.de/de/produkte/gemeindeverzeichnis",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "b20b6ddd2023f309fac69bde3cb7d8e7dfcb0ba5",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2022-01-15T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P123",
+              "P854",
+              "P813"
+            ]
+          }
+        ]
+      }
+    ],
+    "P8402": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P8402",
+          "hash": "5da7781f4f511d9322f321270d8a6d936bdc2bf6",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 97362524,
+              "id": "Q97362524"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$c5c7c0d6-46d3-89fb-e489-1b936ac9547f",
+        "rank": "normal"
+      }
+    ],
+    "P8119": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P8119",
+          "hash": "a3ffa3bd41c4f5e5645e172f27f250bfe8216bb6",
+          "datavalue": {
+            "value": "DE.NW.BE",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$7E324CFE-1423-4A92-BD08-F484BFA496C1",
+        "rank": "normal"
+      }
+    ],
+    "P8714": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P8714",
+          "hash": "2cca9aa561dfd2accf478597ccab180c37de9c59",
+          "datavalue": {
+            "value": "DEU.10.1_1",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$DCB5939F-08FB-4C7B-90AB-0A4D2A943255",
+        "rank": "normal"
+      }
+    ],
+    "P7982": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P7982",
+          "hash": "ce90161fd367ace84aa061c4f2ced39ba29574af",
+          "datavalue": {
+            "value": "7497",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$56FE67B6-06B2-4F3F-A983-E6085CACF74F",
+        "rank": "normal"
+      }
+    ],
+    "P8744": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P8744",
+          "hash": "8ed8a7e495026b2d4faede632feef6ba7a924114",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 100868437,
+              "id": "Q100868437"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$ADBF248C-159F-496A-9DF3-D4D572C1301A",
+        "rank": "normal"
+      }
+    ],
+    "P9100": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P9100",
+          "hash": "5d3c9ff4f0f8a9d5a85d0e9262faa58593a34b02",
+          "datavalue": {
+            "value": "bielefeld",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$4BDD5D8B-754A-4F69-B972-27BD972BBD45",
+        "rank": "normal"
+      }
+    ],
+    "P8168": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P8168",
+          "hash": "b854b2f1797e185072bb944730ea1f85ff3f09bc",
+          "datavalue": {
+            "value": "Q21454",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$2A980168-C428-44B1-A16F-5189A919F63D",
+        "rank": "normal"
+      }
+    ],
+    "P1889": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1889",
+          "hash": "a4989a7ade590711b74b17b8d5bee041a86c14e6",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 857318,
+              "id": "Q857318"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$A5F84A04-956E-400E-A59A-3EA50A80CCA8",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "e19e2dee07249fa024465ae75ccb776a37a5d5c0",
+            "snaks": {
+              "P143": [
+                {
+                  "snaktype": "value",
+                  "property": "P143",
+                  "hash": "39224a9c2e8ce5424defbd16603d25771956c7fc",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 1551807,
+                      "id": "Q1551807"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P4656": [
+                {
+                  "snaktype": "value",
+                  "property": "P4656",
+                  "hash": "09e096a213e9c127bee7f9e54571198c2622170c",
+                  "datavalue": {
+                    "value": "https://pl.wikipedia.org/w/index.php?title=Bielefeld&oldid=63568793",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P143",
+              "P4656"
+            ]
+          }
+        ]
+      }
+    ],
+    "P8189": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P8189",
+          "hash": "62d7abfdb63e2e294531d93c4ad39d5d29917d2b",
+          "datavalue": {
+            "value": "987007557258205171",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$2CF244B5-9985-45E6-B33E-7764CF464541",
+        "rank": "normal"
+      }
+    ],
+    "P4342": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P4342",
+          "hash": "5e00f5ea2dfe333667d2f71ccad7cbd1e4a02e91",
+          "datavalue": {
+            "value": "Bielefeld",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$70C52D70-6E6D-43AD-839F-128802D8D9C5",
+        "rank": "normal"
+      }
+    ],
+    "P1540": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1540",
+          "hash": "916da45e6b810c088240934022557c2f3a1cd99d",
+          "datavalue": {
+            "value": {
+              "amount": "+160802",
+              "unit": "1"
+            },
+            "type": "quantity"
+          },
+          "datatype": "quantity"
+        },
+        "type": "statement",
+        "qualifiers": {
+          "P585": [
+            {
+              "snaktype": "value",
+              "property": "P585",
+              "hash": "426b2cbd07318b722a9fe7c7076cdfb1fc29991b",
+              "datavalue": {
+                "value": {
+                  "time": "+2021-09-30T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                },
+                "type": "time"
+              },
+              "datatype": "time"
+            }
+          ],
+          "P459": [
+            {
+              "snaktype": "value",
+              "property": "P459",
+              "hash": "9a17db6b8b930e6ccfe5013df9d6840428dc679d",
+              "datavalue": {
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 52679562,
+                  "id": "Q52679562"
+                },
+                "type": "wikibase-entityid"
+              },
+              "datatype": "wikibase-item"
+            }
+          ]
+        },
+        "qualifiers-order": [
+          "P585",
+          "P459"
+        ],
+        "id": "Q2112$e87a2e7e-42cb-49ed-98ca-8e7639c13aa2",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "dfbd482b73bdd3d9f13c5380ecd6b633dc4464a0",
+            "snaks": {
+              "P123": [
+                {
+                  "snaktype": "value",
+                  "property": "P123",
+                  "hash": "006e4a871c1adf076c6c611dea42d0700ab67532",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 764739,
+                      "id": "Q764739"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ],
+              "P854": [
+                {
+                  "snaktype": "value",
+                  "property": "P854",
+                  "hash": "408cff8d1a926f7486c60258dd10aefc475eb2cc",
+                  "datavalue": {
+                    "value": "https://www.statistikportal.de/de/produkte/gemeindeverzeichnis",
+                    "type": "string"
+                  },
+                  "datatype": "url"
+                }
+              ],
+              "P813": [
+                {
+                  "snaktype": "value",
+                  "property": "P813",
+                  "hash": "b20b6ddd2023f309fac69bde3cb7d8e7dfcb0ba5",
+                  "datavalue": {
+                    "value": {
+                      "time": "+2022-01-15T00:00:00Z",
+                      "timezone": 0,
+                      "before": 0,
+                      "after": 0,
+                      "precision": 11,
+                      "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                    },
+                    "type": "time"
+                  },
+                  "datatype": "time"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P123",
+              "P854",
+              "P813"
+            ]
+          }
+        ]
+      }
+    ],
+    "P10280": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P10280",
+          "hash": "41846fe5443fd49797c01608f67b98184d339d62",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 16793643,
+              "id": "Q16793643"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$57A78AEA-B206-4831-A8B7-86DA4C52C48F",
+        "rank": "normal"
+      }
+    ],
+    "P9957": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P9957",
+          "hash": "d2ff4f9336373843ed031cf48030ec6a0ae7d7ae",
+          "datavalue": {
+            "value": "301",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$D286E34E-9E98-4721-A76A-644A87499F09",
+        "rank": "normal",
+        "references": [
+          {
+            "hash": "190527dca615f4510213808b0e1cb81522b247f6",
+            "snaks": {
+              "P248": [
+                {
+                  "snaktype": "value",
+                  "property": "P248",
+                  "hash": "9d638c2b86f0a48538336421421d81e676e6a966",
+                  "datavalue": {
+                    "value": {
+                      "entity-type": "item",
+                      "numeric-id": 1360745,
+                      "id": "Q1360745"
+                    },
+                    "type": "wikibase-entityid"
+                  },
+                  "datatype": "wikibase-item"
+                }
+              ]
+            },
+            "snaks-order": [
+              "P248"
+            ]
+          }
+        ]
+      }
+    ],
+    "P8313": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P8313",
+          "hash": "8ff19bdae73b980bf9dbe6a38ac2a271b84023cc",
+          "datavalue": {
+            "value": "Bielefeld",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$11DA0585-CA7C-4ED4-920B-DCA65F22F807",
+        "rank": "normal"
+      }
+    ],
+    "P10397": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P10397",
+          "hash": "335b1c2143e6f2d069846dbce213b8aa86c84558",
+          "datavalue": {
+            "value": "MUSL000400",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$6BAF7B9B-7219-4984-BEF0-4113B573FA2D",
+        "rank": "normal"
+      }
+    ],
+    "P7305": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P7305",
+          "hash": "9c32af09772e782aaa7f338a2436a146eaeeecdb",
+          "datavalue": {
+            "value": "3877389",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$7d0c603e-46c0-1007-e2d7-ed2905fefb9b",
+        "rank": "normal"
+      }
+    ],
+    "P1388": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P1388",
+          "hash": "1bb76555ff83d2d44e75c5ff12d20dfe8a5e2d1f",
+          "datavalue": {
+            "value": "057110000000",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$423a7949-429d-a5f3-8c9b-a8de5bc641b8",
+        "rank": "normal"
+      }
+    ],
+    "P9495": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P9495",
+          "hash": "aa19919e0cc8c9e722c2a2ff2145c5aed2b67cfd",
+          "datavalue": {
+            "value": "geo/79755063-2c14-4e63-94a4-bd6aa2600e9e",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$AA064445-5CD9-4B7F-9BD9-7D8948872D99",
+        "rank": "normal"
+      }
+    ],
+    "P11012": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P11012",
+          "hash": "868a9dd04302ad75a950efa97689098264f05c21",
+          "datavalue": {
+            "value": "Q2474039",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$80B4F3CA-4927-4240-86D8-1F3E07AA6D6B",
+        "rank": "normal"
+      }
+    ],
+    "P6724": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P6724",
+          "hash": "38e05d52d068a18efb4bce3f629bdf8173b64a22",
+          "datavalue": {
+            "value": "10773",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$543262ad-4596-da7c-1282-2d06c304de2e",
+        "rank": "normal"
+      }
+    ],
+    "P4173": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P4173",
+          "hash": "6377547995fd757eda2f6d18f35c31db8e4da9c2",
+          "datavalue": {
+            "value": "221602395",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$05f4a667-41c4-5274-99c9-f0f231596c2b",
+        "rank": "normal"
+      }
+    ],
+    "P237": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P237",
+          "hash": "5e2c9fc9116098ad3c6613173bea8d4049f02450",
+          "datavalue": {
+            "value": {
+              "entity-type": "item",
+              "numeric-id": 106092685,
+              "id": "Q106092685"
+            },
+            "type": "wikibase-entityid"
+          },
+          "datatype": "wikibase-item"
+        },
+        "type": "statement",
+        "id": "Q2112$b22ab3f5-483e-06c9-9183-d361c9cd0bc1",
+        "rank": "normal"
+      }
+    ],
+    "P11693": [
+      {
+        "mainsnak": {
+          "snaktype": "value",
+          "property": "P11693",
+          "hash": "cdb789d77ba179b110cab06216270bafd78f0e5f",
+          "datavalue": {
+            "value": "240037709",
+            "type": "string"
+          },
+          "datatype": "external-id"
+        },
+        "type": "statement",
+        "id": "Q2112$7EC88C93-624D-40C4-A221-6A84F95463E3",
+        "rank": "normal"
+      }
+    ]
+  },
+  "sitelinks": {
+    "afwiki": {
+      "site": "afwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "alswiki": {
+      "site": "alswiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "anwiki": {
+      "site": "anwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "arwiki": {
+      "site": "arwiki",
+      "title": "بيلفلد",
+      "badges": []
+    },
+    "arzwiki": {
+      "site": "arzwiki",
+      "title": "بيليفيلد",
+      "badges": []
+    },
+    "astwiki": {
+      "site": "astwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "azbwiki": {
+      "site": "azbwiki",
+      "title": "بیله‌فلد",
+      "badges": []
+    },
+    "azwiki": {
+      "site": "azwiki",
+      "title": "Bilefeld",
+      "badges": []
+    },
+    "barwiki": {
+      "site": "barwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "bawiki": {
+      "site": "bawiki",
+      "title": "Билефельд",
+      "badges": []
+    },
+    "be_x_oldwiki": {
+      "site": "be_x_oldwiki",
+      "title": "Білефэльд",
+      "badges": []
+    },
+    "bewiki": {
+      "site": "bewiki",
+      "title": "Білефельд",
+      "badges": []
+    },
+    "bgwiki": {
+      "site": "bgwiki",
+      "title": "Билефелд",
+      "badges": []
+    },
+    "cawiki": {
+      "site": "cawiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "cebwiki": {
+      "site": "cebwiki",
+      "title": "Bielefeld (munisipyo)",
+      "badges": []
+    },
+    "cewiki": {
+      "site": "cewiki",
+      "title": "Билефельд",
+      "badges": []
+    },
+    "ckbwiki": {
+      "site": "ckbwiki",
+      "title": "بیلفێلد",
+      "badges": []
+    },
+    "commonswiki": {
+      "site": "commonswiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "cswiki": {
+      "site": "cswiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "cvwiki": {
+      "site": "cvwiki",
+      "title": "Билефелд",
+      "badges": []
+    },
+    "cywiki": {
+      "site": "cywiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "dawiki": {
+      "site": "dawiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "dewiki": {
+      "site": "dewiki",
+      "title": "Bielefeld",
+      "badges": [
+        "Q17437796"
+      ]
+    },
+    "dewikinews": {
+      "site": "dewikinews",
+      "title": "Kategorie:Bielefeld",
+      "badges": []
+    },
+    "dewikiquote": {
+      "site": "dewikiquote",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "dewikisource": {
+      "site": "dewikisource",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "dewikivoyage": {
+      "site": "dewikivoyage",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "diqwiki": {
+      "site": "diqwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "elwiki": {
+      "site": "elwiki",
+      "title": "Μπίλεφελντ",
+      "badges": []
+    },
+    "enwiki": {
+      "site": "enwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "enwikivoyage": {
+      "site": "enwikivoyage",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "eowiki": {
+      "site": "eowiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "eswiki": {
+      "site": "eswiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "etwiki": {
+      "site": "etwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "euwiki": {
+      "site": "euwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "fawiki": {
+      "site": "fawiki",
+      "title": "بیله‌فلد",
+      "badges": []
+    },
+    "fawikivoyage": {
+      "site": "fawikivoyage",
+      "title": "بیلفلد",
+      "badges": []
+    },
+    "fiwiki": {
+      "site": "fiwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "frrwiki": {
+      "site": "frrwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "frwiki": {
+      "site": "frwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "frwikivoyage": {
+      "site": "frwikivoyage",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "fywiki": {
+      "site": "fywiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "glwiki": {
+      "site": "glwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "gvwiki": {
+      "site": "gvwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "hewiki": {
+      "site": "hewiki",
+      "title": "בילפלד",
+      "badges": []
+    },
+    "hrwiki": {
+      "site": "hrwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "hsbwiki": {
+      "site": "hsbwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "huwiki": {
+      "site": "huwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "hywiki": {
+      "site": "hywiki",
+      "title": "Բիլեֆելդ",
+      "badges": []
+    },
+    "iawiki": {
+      "site": "iawiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "idwiki": {
+      "site": "idwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "iewiki": {
+      "site": "iewiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "iswiki": {
+      "site": "iswiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "itwiki": {
+      "site": "itwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "jawiki": {
+      "site": "jawiki",
+      "title": "ビーレフェルト",
+      "badges": []
+    },
+    "kawiki": {
+      "site": "kawiki",
+      "title": "ბილეფილდი",
+      "badges": []
+    },
+    "kkwiki": {
+      "site": "kkwiki",
+      "title": "Билефельд",
+      "badges": []
+    },
+    "kowiki": {
+      "site": "kowiki",
+      "title": "빌레펠트",
+      "badges": []
+    },
+    "kshwiki": {
+      "site": "kshwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "kuwiki": {
+      "site": "kuwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "kywiki": {
+      "site": "kywiki",
+      "title": "Билефельд",
+      "badges": []
+    },
+    "lawiki": {
+      "site": "lawiki",
+      "title": "Bilivelda",
+      "badges": []
+    },
+    "liwiki": {
+      "site": "liwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "lldwiki": {
+      "site": "lldwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "ltwiki": {
+      "site": "ltwiki",
+      "title": "Bylefeldas",
+      "badges": []
+    },
+    "lvwiki": {
+      "site": "lvwiki",
+      "title": "Bīlefelde",
+      "badges": []
+    },
+    "mkwiki": {
+      "site": "mkwiki",
+      "title": "Билефелд",
+      "badges": []
+    },
+    "mnwiki": {
+      "site": "mnwiki",
+      "title": "Билефельд",
+      "badges": []
+    },
+    "mrwiki": {
+      "site": "mrwiki",
+      "title": "बीलेफेल्ड",
+      "badges": []
+    },
+    "nds_nlwiki": {
+      "site": "nds_nlwiki",
+      "title": "Byleveld",
+      "badges": []
+    },
+    "ndswiki": {
+      "site": "ndswiki",
+      "title": "Builefeld",
+      "badges": []
+    },
+    "nlwiki": {
+      "site": "nlwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "nlwikivoyage": {
+      "site": "nlwikivoyage",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "nnwiki": {
+      "site": "nnwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "nowiki": {
+      "site": "nowiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "ocwiki": {
+      "site": "ocwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "oswiki": {
+      "site": "oswiki",
+      "title": "Билефельд",
+      "badges": []
+    },
+    "plwiki": {
+      "site": "plwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "plwikivoyage": {
+      "site": "plwikivoyage",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "pmswiki": {
+      "site": "pmswiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "pnbwiki": {
+      "site": "pnbwiki",
+      "title": "بیلفیلڈ",
+      "badges": []
+    },
+    "ptwiki": {
+      "site": "ptwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "quwiki": {
+      "site": "quwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "rowiki": {
+      "site": "rowiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "ruwiki": {
+      "site": "ruwiki",
+      "title": "Билефельд",
+      "badges": []
+    },
+    "ruwikivoyage": {
+      "site": "ruwikivoyage",
+      "title": "Билефельд",
+      "badges": []
+    },
+    "scowiki": {
+      "site": "scowiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "shwiki": {
+      "site": "shwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "simplewiki": {
+      "site": "simplewiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "skwiki": {
+      "site": "skwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "sqwiki": {
+      "site": "sqwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "srwiki": {
+      "site": "srwiki",
+      "title": "Билефелд",
+      "badges": []
+    },
+    "stqwiki": {
+      "site": "stqwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "svwiki": {
+      "site": "svwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "swwiki": {
+      "site": "swwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "szlwiki": {
+      "site": "szlwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "thwiki": {
+      "site": "thwiki",
+      "title": "บีเลอเฟ็ลท์",
+      "badges": []
+    },
+    "trwiki": {
+      "site": "trwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "ttwiki": {
+      "site": "ttwiki",
+      "title": "Билефелд",
+      "badges": []
+    },
+    "ukwiki": {
+      "site": "ukwiki",
+      "title": "Білефельд",
+      "badges": []
+    },
+    "urwiki": {
+      "site": "urwiki",
+      "title": "بیئلفیلڈ",
+      "badges": []
+    },
+    "uzwiki": {
+      "site": "uzwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "viwiki": {
+      "site": "viwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "vowiki": {
+      "site": "vowiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "warwiki": {
+      "site": "warwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "wuuwiki": {
+      "site": "wuuwiki",
+      "title": "比勒费尔德",
+      "badges": []
+    },
+    "zh_min_nanwiki": {
+      "site": "zh_min_nanwiki",
+      "title": "Bielefeld",
+      "badges": []
+    },
+    "zh_yuewiki": {
+      "site": "zh_yuewiki",
+      "title": "比勒費爾德",
+      "badges": []
+    },
+    "zhwiki": {
+      "site": "zhwiki",
+      "title": "比勒费尔德",
+      "badges": []
+    }
+  }
 }

--- a/tests/general.ts
+++ b/tests/general.ts
@@ -138,8 +138,6 @@ describe('index', () => {
     should(wbk.simplify.propertyClaims).be.a.Function()
     should(wbk.simplify.claims).be.a.Function()
     should(wbk.simplify.snak).be.a.Function()
-    should(wbk.simplify.propertySnaks).be.a.Function()
-    should(wbk.simplify.snaks).be.a.Function()
     should(wbk.simplify.qualifier).be.a.Function()
     should(wbk.simplify.propertyQualifiers).be.a.Function()
     should(wbk.simplify.qualifiers).be.a.Function()

--- a/tests/simplify_claims.ts
+++ b/tests/simplify_claims.ts
@@ -3,7 +3,7 @@ import should from 'should'
 import { simplifyClaim, simplifyPropertyClaims, simplifyClaims } from '../src/helpers/simplify_claims.js'
 import { uniq } from '../src/utils/utils.js'
 import { readJsonFile } from './lib/utils.js'
-import type { Item, Lexeme } from '../src/types/entity.js'
+import type { Item, Lexeme, Property } from '../src/types/entity.js'
 import type { SimplifySnakOptions } from '../src/types/simplify_claims.js'
 
 const L525 = readJsonFile('./tests/data/L525.json') as Lexeme
@@ -18,6 +18,7 @@ const Q4115189 = readJsonFile('./tests/data/Q4115189.json') as Item
 const Q4132785 = readJsonFile('./tests/data/Q4132785.json') as Item
 const Q571 = readJsonFile('./tests/data/Q571.json') as Item
 const Q646148 = readJsonFile('./tests/data/Q646148.json') as Item
+const P3035 = readJsonFile('./tests/data/P3035.json') as Property
 const emptyValues = readJsonFile('./tests/data/empty_values.json') as Item
 const lexemeClaim = readJsonFile('./tests/data/lexeme_claim.json')
 const oldClaimFormat = readJsonFile('./tests/data/old_claim_format.json')
@@ -57,16 +58,16 @@ describe('simplifyClaims', () => {
   it('should pass entity and property prefixes down', () => {
     const simplified = simplifyClaims(Q2112.claims, { entityPrefix: 'wd' })
     should(simplified.P190[0]).equal('wd:Q207614')
-    const simplified2 = simplifyClaims(Q2112.claims, { propertyPrefix: 'wdt' })
-    should(simplified2['wdt:P123456789'][0]).equal('P207614')
+    const simplified2 = simplifyClaims(P3035.claims, { propertyPrefix: 'wdt' })
+    should(simplified2['wdt:P1659'][0]).equal('P212')
   })
 
   it('should return prefixed properties if passed a property prefix', () => {
     const simplified = simplifyClaims(Q2112.claims, { entityPrefix: 'wd', propertyPrefix: 'wdt' })
     should(simplified['wdt:P190']).be.an.Array()
     should(simplified['wdt:P190'][0]).equal('wd:Q207614')
-    const simplified2 = simplifyClaims(Q2112.claims, { propertyPrefix: 'wdt' })
-    should(simplified2['wdt:P123456789'][0]).equal('P207614')
+    const simplified2 = simplifyClaims(P3035.claims, { propertyPrefix: 'wdt' })
+    should(simplified2['wdt:P1659'][0]).equal('P212')
   })
 
   it('should return the correct value when called with keepQualifiers=true', () => {
@@ -121,8 +122,8 @@ describe('simplifyPropertyClaims', () => {
   it('should pass entity and property prefixes down', () => {
     const simplified = simplifyPropertyClaims(Q2112.claims.P190, { entityPrefix: 'wd' })
     should(simplified[0]).equal('wd:Q207614')
-    const simplified2 = simplifyPropertyClaims(Q2112.claims.P123456789, { entityPrefix: 'a', propertyPrefix: 'b' })
-    should(simplified2[0]).equal('a:P207614')
+    const simplified2 = simplifyPropertyClaims(P3035.claims.P1659, { entityPrefix: 'a', propertyPrefix: 'b' })
+    should(simplified2[0]).equal('a:P212')
   })
 
   it('should return the correct value when called with keepQualifiers=true', () => {
@@ -270,7 +271,7 @@ describe('simplifyClaim', () => {
       const simplified = simplifyClaim(Q2112.claims.P625[0])
       should(simplified).be.an.Array()
       should(simplified[0]).equal(52.016666666667)
-      should(simplified[1]).equal(8.5166666666667)
+      should(simplified[1]).equal(8.5333333333333)
     })
 
     it('should support geo-shape', () => {
@@ -308,14 +309,14 @@ describe('simplifyClaim', () => {
     })
 
     it('should not apply property prefixes to property claim values', () => {
-      const claim = Q2112.claims.P123456789[0]
-      should(simplifyClaim(claim)).equal('P207614')
-      should(simplifyClaim(claim, { propertyPrefix: 'wdt' })).equal('P207614')
-      should(simplifyClaim(claim, { propertyPrefix: 'wdt:' })).equal('P207614')
-      should(simplifyClaim(claim, { propertyPrefix: 'wdtbla' })).equal('P207614')
-      should(simplifyClaim(claim, { entityPrefix: 'wd' })).equal('wd:P207614')
-      should(simplifyClaim(claim, { entityPrefix: 'wd:' })).equal('wd::P207614')
-      should(simplifyClaim(claim, { entityPrefix: 'wdbla' })).equal('wdbla:P207614')
+      const claim = P3035.claims.P1659[0]
+      should(simplifyClaim(claim)).equal('P212')
+      should(simplifyClaim(claim, { propertyPrefix: 'wdt' })).equal('P212')
+      should(simplifyClaim(claim, { propertyPrefix: 'wdt:' })).equal('P212')
+      should(simplifyClaim(claim, { propertyPrefix: 'wdtbla' })).equal('P212')
+      should(simplifyClaim(claim, { entityPrefix: 'wd' })).equal('wd:P212')
+      should(simplifyClaim(claim, { entityPrefix: 'wd:' })).equal('wd::P212')
+      should(simplifyClaim(claim, { entityPrefix: 'wdbla' })).equal('wdbla:P212')
     })
   })
 
@@ -432,16 +433,18 @@ describe('simplifyClaim', () => {
     it('should include references hashes when called with keepHashes=true', () => {
       const simplifiedWithReferences = simplifyClaim(Q2112.claims.P214[0], { keepReferences: true, keepHashes: true })
       should(simplifiedWithReferences.references[0].snaks.P248).be.an.Array()
-      should(simplifiedWithReferences.references[0].hash).equal('d6b4bc80e47def2fab91836d81e1db62c640279c')
-      should(simplifiedWithReferences.references[0].snaks.P248[0]).equal('Q54919')
+      should(simplifiedWithReferences.references[0].hash).equal('94cd09bdd3373d7b8eb4e3cc26e524afe7466ff7')
+      should(simplifiedWithReferences.references[0].snaks.P248[0].value).equal('Q54919')
+      should(simplifiedWithReferences.references[0].snaks.P248[0].hash).equal('6b7d4330c4aac4caec4ede9de0311ce273f88ecd')
       should(simplifiedWithReferences.references[0].snaks.P813).be.an.Array()
-      should(simplifiedWithReferences.references[0].snaks.P813[0]).equal('2015-08-02T00:00:00.000Z')
+      should(simplifiedWithReferences.references[0].snaks.P813[0].value).equal('2015-08-02T00:00:00.000Z')
+      should(simplifiedWithReferences.references[0].snaks.P813[0].hash).equal('bf4494cf3e2345d75aa355a5847a72d38ca6c55d')
     })
 
     it('should include qualifiers hashes when called with keepHashes=true', () => {
       const simplifiedWithQualifiers = simplifyPropertyClaims(Q2112.claims.P190, { keepQualifiers: true, keepHashes: true })
       should(simplifiedWithQualifiers[1].qualifiers.P580[0].value).equal('1953-01-01T00:00:00.000Z')
-      should(simplifiedWithQualifiers[1].qualifiers.P580[0].hash).equal('3d22f4dffba1ac6f66f521ea6bea924e46df4129')
+      should(simplifiedWithQualifiers[1].qualifiers.P580[0].hash).equal('a5e0dc0fab1c88e0702eab5557dfec4f8ab8a289')
     })
   })
 
@@ -463,7 +466,7 @@ describe('simplifyClaim', () => {
     it('should keep globecoordinate rich values', () => {
       should(simplifyClaim(Q2112.claims.P625[0], { keepRichValues: true })).deepEqual({
         latitude: 52.016666666667,
-        longitude: 8.5166666666667,
+        longitude: 8.5333333333333,
         altitude: null,
         precision: 0.016666666666667,
         globe: 'http://www.wikidata.org/entity/Q2',
@@ -560,7 +563,7 @@ describe('simplifyClaim', () => {
       should(simplifiedP214.references[0].hash).be.a.String()
       should(simplifiedP625.value).deepEqual({
         latitude: 52.016666666667,
-        longitude: 8.5166666666667,
+        longitude: 8.5333333333333,
         altitude: null,
         precision: 0.016666666666667,
         globe: 'http://www.wikidata.org/entity/Q2',


### PR DESCRIPTION
`simplifyClaim` and `simplifySnak` are currently aliases of the same function, which creates complexity and confusion, as a claim has itself a `mainsnak`. By splitting those functions, typing also becomes easier.

Any opinion @EdJoPaTo @mshd?