### PR TITLE
ci(nodejs): only run on LTS version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,21 +6,13 @@ on:
 
 jobs:
   test:
-    name: Node.js ${{ matrix.node-version }}
+    name: Node.js
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - 18
-          - 16
-          - 14
-          - 12
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-      - uses: actions/checkout@v3
+          node-version: 'lts/*'
+      - uses: actions/checkout@v4
       - run: npm install
       - run: npm test
       - run: npm pack


### PR DESCRIPTION
Node.js 20 will be a LTS version from 2023-10-24. Its probably a good idea to also test against it.